### PR TITLE
rnpm in now in react-native

### DIFF
--- a/_posts/1-2-1-Introduction.md
+++ b/_posts/1-2-1-Introduction.md
@@ -23,7 +23,6 @@ Before starting make sure you have:
 
 - Installed [node](https://nodejs.org/en/)
 - Installed [npm](https://www.npmjs.com/)
-- Installed [rnpm](https://github.com/rnpm/rnpm)
 - Installed [React Native](https://facebook.github.io/react-native/docs/getting-started.html)
 
 ## Installation
@@ -37,12 +36,7 @@ $ react-native init HelloWorld
 Install `@shoutem/ui` in your project:
 
 ```bash
-$ npm i -S @shoutem/ui
-```
-Then run `rnpm` to link fonts that the toolkit is using.
-
-```bash
-$ rnpm link
+$ react-native install @shoutem/ui
 ```
 
 To check which components we have in UI toolkit, simply copy the following to your `index.ios.js` file of React Native project:


### PR DESCRIPTION
You don't need to install rnpm anymore. `react-native install` does both `npm install --save` and `rnpm link`
