### PR TITLE
Fixes docs to have correct prop for StyleProvider

### DIFF
--- a/_posts/1-2-2-Theme.md
+++ b/_posts/1-2-2-Theme.md
@@ -115,7 +115,7 @@ import { StyleProvider } from '@shoutem/theme';
 
 class App extends Component {
   render() {
-    <StyleProvider theme={theme}>
+    <StyleProvider style={theme}>
       // any app components
     </StyleProvider>
   }


### PR DESCRIPTION
`StyleProvider` has a prop called `style` to provide the theme styles. The docs show `theme` which doesn't work.