### PR TITLE
Updating Setting Local Environment Documentation

### DIFF
--- a/docs/extensions/tutorials/_posts/1970-01-01-GettingStarted.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-GettingStarted.md
@@ -110,7 +110,7 @@ File `app/extension.js` was modified.
 File `extension.json` was modified.
 ```
 
-This created `Hello` screen in `app/screens/List.js` file. Any time you create a new screen it'll be a simple "Hello World!" screen.
+This created `Hello` screen in `app/screens/Hello.js` file. Any time you create a new screen it'll be a simple "Hello World!" screen.
 
 Let's push what we've built to Shoutem.
 

--- a/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
@@ -19,13 +19,29 @@ Before setting up a local environment for building Shoutem extensions, set up Re
 <img src='{{ site.url }}/img/tutorials/setting-local-environment/rn-getting-started.png'/>
 </p>
 
-In that tutorial, previewing changes in iOS apps locally is only available on Mac. That's not the case when you're using Shoutem. You can test your React Native apps on iOS platform by using the **Shoutem Preview App** (available for [iOS]({{ site.shoutem.previewAppiOS }}) and [Android]({{ site.shoutem.previewAppAndroid }})) for testing your app on a physical iOS device or just using the [Shoutem Builder]({{ site.shoutem.builderURL }}) for testing it on an iOS simulator.
+In that tutorial, previewing changes in iOS apps locally is only available on Mac. That's not the case when you're using Shoutem. You can test your React Native apps on iOS platform by using the **Shoutem Preview app** (available for [iOS]({{ site.shoutem.previewAppiOS }}) and [Android]({{ site.shoutem.previewAppAndroid }})) for testing your app on a physical iOS device or just using the [Shoutem Builder]({{ site.shoutem.builderURL }}) for testing it on an iOS simulator.
+
+## Previewing apps
+
+There are three different ways you can preview your app using Shoutem, we'll explain each of them in this section. Do note, here we're only talking about previewing your app, for previewing _changes_ in real time, check the **Local Development** section.
+
+#### Shoutem Run
+
+`shoutem run` is used to preview the app on your device using the the **Shoutem Preview app**. The great thing about the Shoutem Preview app is that it will let you see what the app looks like on iOS even if you're using Windows.
+
+However, there are limitations to what the Shoutem Preview app can preview. Namely, it can only preview code that has no native code linked into it. This is because the Shoutem Preview app has it's own binary, so it can only preview changes made to the JavaScript bundle of the app.
+
+#### Shoutem Run-OS
+
+`shoutem run-ios` and `shoutem run-android` are used for previewing the app locally on an emulator. They work analogously to `react-native run-ios` and `react-native run-android`, so they require you to set up your React Native environment as stated earlier in the tutorial.
+
+#### Shoutem Builder
+
+You can of course preview your app through the Shoutem Builder where you can manage your app as well. It works identically to the Shoutem Preview app, having the same advantages and limitations.
 
 ## Local Development
 
-If you've gone through the **Getting Started** tutorial, you should have an app on the Builder. To preview it locally, use `shoutem run-ios` (or `shoutem run-android` for Android) and select your app from the list. Previewing it like this will take the code from Shoutem and preview the app locally, however, to see changes you make to your extension, you'll have to _push_ them to Shoutem after every change. Obviously, this is not efficientm since _Pushing_ your extension to Shoutem and waiting for Shoutem to build the new app is time consuming.
-
-This is why you _link_ your local extension code to the local environment (similar to [react-native link](https://facebook.github.io/react-native/docs/linking-libraries-ios.html)). Next time you run the app, Shoutem will take the local extension code instead of taking it from the Builder, so you don't have to wait through the `push` and download.
+We will now explain how to preview code changes in your extensions in real-time. If you've gone through the **Getting Started** tutorial, you should have an app on the Builder. To be able to see changes in your extension as you make them **without** having to push your extension to Shoutem every time you make a change, you'll have to _link_ your local extension code to the local environment (similar to [react-native link](https://facebook.github.io/react-native/docs/linking-libraries-ios.html)).
 
 Navigate to your extension directory and link it to your local environment:
 
@@ -48,9 +64,9 @@ Running `News app` app on `iPhone 6` simulator...
 > #### Note
 > The name of your app may be different if you decided to rename it in the Builder, simply make sure to select the app you installed your Hello World extension into.
 
-When the app was run, code from linked extensions was taken locally and other extensions were fetched from Shoutem server. Running the app will take some time (around 3-4mins), but now you can develop your extension much faster because you can see the changes you make to your extension in real time, exactly like a regular React Native app.
+When the app was run, the code from your linked extension was taken locally and other extensions were fetched from Shoutem server. Running the app will take some time (around 3-4mins), but now you can develop your extension much faster because you can see the changes you make to your extension in real time, exactly like a regular React Native app.
 
-Change something inside your extension. For example, you could add another line of `<Text>`:
+Lets see how this works. Change something inside your extension, for example you could add another line of `<Text>`:
 
 ```javascript{5}
   render() {
@@ -63,7 +79,7 @@ Change something inside your extension. For example, you could add another line 
   }
 ```
 
-Now to see the changes you saved, you don't need to do `shoutem push` anymore, you can just reload the app:
+Save the changes. Now you don't need to do `shoutem push` anymore since you linked this extension to your local environment. You can just reload the app:
 
 - On simulator:
   - iOS: press `Command ⌘` + `R`

--- a/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
@@ -7,12 +7,9 @@ section: Tutorials
 
 # Setting up your Local Environment
 
-This tutorial explains how to build extensions without the need to _push_ them to Shoutem. Setting up local development will help you develop your extensions much faster with the ability to debug and test it on your own physical device or emulator.
+In this tutorial we will explain how to set up a local environment that allows you to preview changes to your app in real time. In other words, once you're set up, you won't have to upload your extension to Shoutem every time you want to see the changes you made to it. You can do this using your own physical device or an emulator.
 
-Make sure you understand concepts introduced in [Getting started]({{ site.url }}/docs/extensions/tutorials/getting-started) before reading this tutorial, it'll make it a lot easier to follow.
-
-> #### Note
-> To test this out, you need an app that uses your own, custom extension. If you don't have an app like that set up, [download](https://github.com/shoutem/extension-examples/tree/master/restaurants-getting-started) the extension from My First Extension and install it with `shoutem install --new` to a new app. Now, add the screen to app navigation and add some content. If this all sounds confusing, just head over to [My First Extension]({{ site.url }}/docs/extensions/my-first-extension/introduction).
+To be able to follow this tutorial, you should go through our [Getting Started]({{ site.url }}/docs/extensions/tutorials/getting-started) tutorial so you have a `Hello World` extension to test your local environment with.
 
 ## React Native Environment
 
@@ -22,39 +19,20 @@ Before setting up a local environment for building Shoutem extensions, set up Re
 <img src='{{ site.url }}/img/tutorials/setting-local-environment/rn-getting-started.png'/>
 </p>
 
-In that tutorial, building iOS apps locally is only available on Mac. Lies and slander! Using Shoutem, you can test your React Native apps on iOS platform by using the **Shoutem Preview App** (available for [iOS]({{ site.shoutem.previewAppiOS }}) and [Android]({{ site.shoutem.previewAppAndroid }})) for testing your app on a physical iOS device or just using the [Shoutem Builder]({{ site.shoutem.builderURL }}) for testing it on an iOS simulator.
-
-## Local Preview
-
-Once you create an app on Shoutem, preview it on a local simulator by running:
-
-```ShellSession
-$ shoutem run-ios
-Select a device: iPhone 6
-Select your app: Restaurants ({{ site.example.appId }})
-Running `Restaurants` app on `iPhone 6` simulator...
-...
-```
-
-This command takes the code from Shoutem Builder. For Android, use `shoutem run-android`.
+In that tutorial, previewing changes in iOS apps locally is only available on Mac. That's not the case when you're using Shoutem. You can test your React Native apps on iOS platform by using the **Shoutem Preview App** (available for [iOS]({{ site.shoutem.previewAppiOS }}) and [Android]({{ site.shoutem.previewAppAndroid }})) for testing your app on a physical iOS device or just using the [Shoutem Builder]({{ site.shoutem.builderURL }}) for testing it on an iOS simulator.
 
 ## Local Development
 
-_Pushing_ your extension to Shoutem and waiting for Shoutem to build the new app is time consuming. Just running your app locally doesn't solve this problem since it still takes the code from Shoutem.
+If you've gone through the **Getting Started** tutorial, you should have an app on the Builder. To preview it locally, use `shoutem run-ios` (or `shoutem run-android` for Android) and select your app from the list. Previewing it like this will take the code from Shoutem and preview the app locally, however, to see changes you make to your extension, you'll have to _push_ them to Shoutem after every change. Obviously, this is not efficientm since _Pushing_ your extension to Shoutem and waiting for Shoutem to build the new app is time consuming.
 
-However, you can _link_ your local extension code to the local environment (similar to [react-native link](https://facebook.github.io/react-native/docs/linking-libraries-ios.html)). Next time you run the app, Shoutem will take the local extension code instead of taking it from the Builder, so you don't have to wait through the `push` and download.
+This is why you _link_ your local extension code to the local environment (similar to [react-native link](https://facebook.github.io/react-native/docs/linking-libraries-ios.html)). Next time you run the app, Shoutem will take the local extension code instead of taking it from the Builder, so you don't have to wait through the `push` and download.
 
-Navigate to your extension directory:
-
-```ShellSession
-$ cd restaurants
-```
-
-... and link the extension:
+Navigate to your extension directory and link it to your local environment:
 
 ```ShellSession
+$ cd hello-world
 $ shoutem link
-Extension successfully linked. Please, kill the packager before running the app.
+Directory successfully linked. Please, kill the packager before running the app.
 ```
 
 Run the app that uses the extension you just linked:
@@ -62,35 +40,30 @@ Run the app that uses the extension you just linked:
 ```ShellSession
 $ shoutem run-ios
 Select a device: iPhone 6
-Select your app: Restaurants ({{ site.example.appId }})
-Running `Restaurants` app on `iPhone 6` simulator...
+Select your app: News app ({{ site.example.appId }})
+Running `News app` app on `iPhone 6` simulator...
 ...
 ```
 
-When the app was run, code from linked extensions was taken locally and other extensions were fetched from Shoutem server. Running the app will take some time (around 3-4mins), but now you can develop your extension much faster.
+> #### Note
+> The name of your app may be different if you decided to rename it in the Builder, simply make sure to select the app you installed your Hello World extension into.
 
-Change something inside your extension. For instance, change `RESTAURANTS` to `PLACES WITH NOM-NOMS` in `app/screens/List.js`:
+When the app was run, code from linked extensions was taken locally and other extensions were fetched from Shoutem server. Running the app will take some time (around 3-4mins), but now you can develop your extension much faster because you can see the changes you make to your extension in real time, exactly like a regular React Native app.
 
-```javascript{6}
+Change something inside your extension. For example, you could add another line of `<Text>`:
+
+```javascript{5}
   render() {
-    const { restaurants } = this.props;
-
     return (
-      <Screen>
-        <NavigationBar title="PLACES WITH NOM-NOMS" />
-        <ListView
-          data={restaurants}
-          loading={isBusy(restaurants)}
-          renderRow={restaurant => this.renderRow(restaurant, navigateTo)}
-        />
-      </Screen>
+      <View style={styles.container}>
+        <Text style={styles.text}>Hello World!</Text>
+        <Text style={styles.text}>This is my first extension!</Text>
+      </View>
     );
   }
 ```
 
-Save your changed nom-noms file.
-
-Now to see the changes, you don't need to do `shoutem push` anymore you can just reload the app:
+Now to see the changes you saved, you don't need to do `shoutem push` anymore, you can just reload the app:
 
 - On simulator:
   - iOS: press `Command ⌘` + `R`
@@ -99,16 +72,16 @@ Now to see the changes, you don't need to do `shoutem push` anymore you can just
 
 If you enable automatic reloading, the previous step is unnecessary. Having local environment set, you can also debug your extension. Follow the React Native guide on [debugging](https://facebook.github.io/react-native/docs/debugging.html) where you can find out how automatic reloading works as well.
 
-To see which extensions are linked (as well as which developer is signed in), run:
+To see which extensions are linked, as well as which developer is signed in, run:
 
 ```ShellSession
 $ shoutem show
-Signed in as `{{ site.example.devName }}`.
-Linked extensions:
-  `restaurants` -> ~/{{ site.example.devName }}/extensions/restaurants
+Linked directories:
+  /Path/to/hello-world
+Registered as `{{ site.example.devName }}`.
 ```
 
-To unlink extension, locate to that folder and do:
+To unlink an extension, locate to that folder and do:
 
 ```ShellSession
 $ shoutem unlink
@@ -117,44 +90,29 @@ Unlink successful. Please, kill the packager before running the app.
 
 ... or just delete the extension.
 
-You can also do `shoutem unlink --all`, but be careful with it, don't want to end up re-linking all those awesome extensions you'll be working on.
+You can also do `shoutem unlink --all`, but make sure you don't mind unlinking all the extensions you have linked.
 
-## App Project
+## Getting the Full App Code
 
-When you push your extension to Shoutem, we build the app with that extension for you. However, sometimes you might want to see the full picture - what the complete app project looks like.
-
-Get the complete app code:
+When you push your extension to Shoutem, we build the app with that extension for you. However, sometimes you might want to see the full picture - what the complete app project looks like. To get your Shoutem-built app's code, you can use:
 
 ```ShellSession
 $ shoutem pull-app
-Select the app you want to pull: Restaurants ({{ site.example.appId }})
-Pulling the app `Restaurants`...
+Select the app you want to pull: News app ({{ site.example.appId }})
+Pulling the app `News app`...
 Pulling extensions...
 Success!
-Change your working directory to `Restaurants`.
+Change your working directory to `News_app`.
 ```
 
-Locate to `Restaurants` directory:
+Locate to `News_app` directory and open it:
 
 ```ShellSession
-$ cd Restaurants
+$ cd News_app
+$ open .
 ```
 
-Check how the project structure looks like. It should look familiar - because this is how usual React Native project looks like. The `index.js` file is the starting point.
-
-Notice the `extensions` folder. It contains all the extensions installed in the app (you can see them in **Extensions** tab for your app). Run the app from that folder:
-
-```ShellSession
-$ shoutem run-ios
-...
-```
-
-This will run the app that has been fetched locally. It will use all the extensions from `extensions` folder, so you can change something locally and see the change when you reload the app.
-
-> #### Note
-> Extensions inside the app project folder are only linked to the local app, so when you run the `shoutem run-ios` outside of that folder, you won't get them linked. If you want them linked, go inside of the specific folder in `extensions` and run `shoutem link`.
-
-Once you're satisfied with your extension, just push it to the Shoutem as your own extension with `shoutem push`.
+Check what the project structure looks like. It should look familiar, because this is what regular React Native projects look like. The `index.js` file is the starting point. The `extensions` folder contains all the extensions installed in the app (all of the ones in the **Extensions** tab of your app in the Builder, not just the ones whose Screens you've added).
 
 ## Best Practises
 


### PR DESCRIPTION
This is the initial change that include clarity, grammar and phrasing edits.

I've also changed the extension example from the Restaurants example to the "Getting Started" Hello World extension to reduce the time it takes for users to get to the point where they can develop locally, as well as keep the example simple.

Emphasised difference between previewing locally and developing locally.

Explained differences between `shoutem run` and `shoutem run-ios/android`.

Explained limitations of the Builder preview and Shoutem Preview app while also emphasising the usefulness of the Shoutem Preview app for Windows users that want to see their app on iOS.


The first commit also includes a very minor fix to "Getting Started", where a file is called List.js instead of Hello.js.