### PR TITLE
Updating Shoutem UI Toolkit Documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,11 +9,11 @@ sass:
 # Build settings
 markdown: kramdown
 
-kramdown: 
+kramdown:
   syntax_highlighter_opts:
     disable : true
 
-url: "//shoutem.github.io"
+url: "https://shoutem.github.io"
 
 # Variables
 shoutem:
@@ -32,8 +32,8 @@ external:
   googlePlayDeveloperAccount: "https://play.google.com/apps/publish/signup/"
   xcode: "https://developer.apple.com/xcode/"
   androidStudio: "https://developer.android.com/studio/index.html"
-  
-  
+
+
 
 # Examples
 example:

--- a/docs/ui-toolkit/animation/_posts/1970-01-02-Driver.md
+++ b/docs/ui-toolkit/animation/_posts/1970-01-02-Driver.md
@@ -9,10 +9,10 @@ section: Animation
 
 An animation is driven by the `driver`. It encapsulates the creation of animation [input events](https://facebook.github.io/react-native/docs/animations.html#input-events), making React Native animations even more declarative. Drivers are attached to animation components which are set to listen to specific driver inputs.
 
-Currently, 2 drivers are supported:
+Currently, two drivers are supported:
 
-- `ScrollDriver`, that binds scrolling of RN [ScrollView](https://facebook.github.io/react-native/docs/scrollview.html) to the attaching animation components and
-- `TimingDriver`, that creates animated values changing with time
+- `ScrollDriver`, that binds scrolling of React Native's [ScrollView](https://facebook.github.io/react-native/docs/scrollview.html) to the animation components and
+- `TimingDriver`, that creates animated values that change with time
 
 
 ## ScrollDriver
@@ -68,7 +68,7 @@ class Screen extends React.Component {
 
 To trigger the start of the timer, call `runTimer` method on `TimingDriver` instance. The signature of `runTimer` method is as follows:
 
-#### `runTimer(endValue, onFinish)`: 
+#### `runTimer(endValue, onFinish)`:
 
 - `endValue`: Number, when the timer reaches this value the animations will end
 - `onFinish` Function, callback that will be called upon reaching `endValue`

--- a/docs/ui-toolkit/animation/_posts/1970-01-03-Animations.md
+++ b/docs/ui-toolkit/animation/_posts/1970-01-03-Animations.md
@@ -8,14 +8,14 @@ section: Animation
 # Animation
 <hr />
 
-When building an application, there is a need to create animations to enrich the user experience. Although React Native [provides a way](https://facebook.github.io/react-native/docs/animations.html) to implement arbitrary animations, it is not an easy task to do, even for simple animations. That's where `@shoutem/animation` package comes in. The package contains **animation [components](#components)** that should be wrapped around components that you want to animate, and [**driver**](#driver) that _drives_ the animation components.
+When building an app, there's always a need to create animations to enrich the user experience. Although React Native [provides a way](https://facebook.github.io/react-native/docs/animations.html) to implement arbitrary animations, it is not an easy task to do, even for simple animations. That's where `@shoutem/animation` package comes in. The package contains **animation [components](#components)** that should be wrapped around components that you want to animate, and [**drivers**](#driver) that _drive_ the animation components.
 
 ## Installation
 
 Simply install it with:
 
-```bash
-npm install @shoutem/animation
+```ShellSession
+$ npm install @shoutem/animation
 ```
 
 ## New animations - coming soon

--- a/docs/ui-toolkit/animation/_posts/1970-01-05-ZoomIn.md
+++ b/docs/ui-toolkit/animation/_posts/1970-01-05-ZoomIn.md
@@ -27,7 +27,7 @@ Zooms in components wrapped by it.
 
 ## Example
 <br />  
-  
+
 #### JSX declaration
 ```javascript
 const driver = new ScrollDriver();

--- a/docs/ui-toolkit/components/_posts/1970-01-02-Typography.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-02-Typography.md
@@ -7,7 +7,7 @@ section: UI toolkit
 
 # Typography
 
-Typography components consist of several flavors of `Text` components with predefined styles. Available components are: 
+Typography components consist of several flavors of `Text` components with predefined styles. Available components are:
 
 ```JSX
 <Heading>...</Heading>
@@ -22,7 +22,7 @@ Typography components consist of several flavors of `Text` components with prede
 ## API
 
 #### Props
-* Every component in this section supports every `prop` that the standard React Native `Text` component supports (i.e. `numberOfLines`). See full list of available props on  React Native [Text component documentation](https://facebook.github.io/react-native/docs/text.html "React Native Text component documentation")  
+* Every component in this section supports every `prop` that the standard React Native `Text` component supports (eg. `numberOfLines`). You can see the full list of available props on React Native [Text component documentation](https://facebook.github.io/react-native/docs/text.html "React Native Text component documentation").
 
 #### Style names
 
@@ -30,7 +30,7 @@ Typography components consist of several flavors of `Text` components with prede
 * **bright**: Sets text color to the `Light` color set in the theme
 * **h-center**: Centers the text horizontally
 * **line-through**: Defines a line through the text
-* **multiline**: Increases line-height to allow text to wrap 
+* **multiline**: Increases line-height to allow text to wrap
 * **v-center**: Works only in combination with `multiline` styleName. Applies additional top and bottom margins to compensate the unsupported `textAlignVertical` prop on iOS
 
 

--- a/docs/ui-toolkit/components/_posts/1970-01-03-NavigationBar.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-03-NavigationBar.md
@@ -13,7 +13,7 @@ Shoutem UI toolkit contains two different `NavigationBar` components:
 
 ![Navbar / Solid example]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-title-only@2x.png "Navbar / Solid"){:.docs-component-image}
 
-2) `Redux` and stack-based `NavigationBar` enables any view to act as a navigation view using reducers to manipulate state at a top-level object. Can be used only on components that are within the stack (i.e. it cannot be used on `Modal` window). Internally, it relies on [`NavigationExperimental`](https://facebook.github.io/react-native/docs/navigation.html#navigationexperimental) from React-Native 
+2) `Redux` and stack-based `NavigationBar` enables any view to act as a navigation view using reducers to manipulate state at a top-level object. Can be used only on components that are within the stack (i.e. it cannot be used on `Modal` window). Internally, it relies on [`NavigationExperimental`](https://facebook.github.io/react-native/docs/navigation.html#navigationexperimental) from React-Native.
 
 
 
@@ -34,7 +34,7 @@ import { NavigationBar } from '@shoutem/ui'
 
 * **centerComponent**: object  
   - represents the center component in `NavigationBar` (i.e. screen title)
-  
+
 * **leftComponent**: object  
   - represents the left component in `NavigationBar` (i.e. back button)
 
@@ -51,7 +51,7 @@ import { NavigationBar } from '@shoutem/ui'
 
 * **clear**: sets the `Text` color to white and background colors to transparent
 * **inline**: forces relative positioning of `NavigationBar` component, allowing component to be used inline with other components, i.e. `ListView`, without its content overlapping `NavigationBar`
-* **no-border**: removes the bottom border 
+* **no-border**: removes the bottom border
 
 #### Style
 
@@ -60,10 +60,10 @@ import { NavigationBar } from '@shoutem/ui'
 
 * **container**
   - Style for `View` that holds all components within `NavigationBar`
-  
+
 * **componentsContainer**
   - Style for `View` container that holds `leftComponent`, `centerComponent` and `rightComponent` objects
-  
+
 * **leftComponent**
   - Style applied to left navigation component
 
@@ -83,7 +83,7 @@ import { NavigationBar } from '@shoutem/ui'
 />
 ```
 
-### Clear (Image)
+### Showing Background Image
 ![Clear (Image) example]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-imageoverlay-image@2x.png "Clear (Image)"){:.docs-component-image}
 
 #### JSX Declaration
@@ -153,7 +153,7 @@ import { NavigationBar } from '@shoutem/ui'
 />
 ```
 
-### Navbar + Icon
+### Navbar + Icon Button
 ![Navbar + Icon example]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-icon@2x.png "Navbar + Icon"){:.docs-component-image}
 
 #### JSX Declaration
@@ -176,7 +176,7 @@ import { NavigationBar } from '@shoutem/ui'
 ```JSX
 <NavigationBar
   hasHistory
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   share={% raw %}{{{% endraw %}
     link: 'http://shoutem.github.io',
     text: 'This is the best',
@@ -193,7 +193,7 @@ import { NavigationBar } from '@shoutem/ui'
 <NavigationBar
   styleName="no-border"
   hasHistory
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   share={% raw %}{{{% endraw %}
     link: 'http://shoutem.github.io',
     text: 'This is the best',
@@ -209,7 +209,7 @@ import { NavigationBar } from '@shoutem/ui'
 ```JSX
 <NavigationBar
   hasHistory
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   rightComponent={(
     <Button styleName="clear">
       <Text>Report</Text>
@@ -218,8 +218,8 @@ import { NavigationBar } from '@shoutem/ui'
 />
 ```
 
-### Navbar (Modal) + Icon
-![Navbar (Modal) + Icon example]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-modal-icon@2x.png "Navbar (Modal) + Icon"){:.docs-component-image}
+### Navbar (Modal) + Share Button
+![Navbar (Modal) + Share Button]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-modal-icon@2x.png "Navbar (Modal) + Icon"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX
@@ -229,7 +229,7 @@ import { NavigationBar } from '@shoutem/ui'
       <Icon name="close" />
     </Button>
   )}
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   share={% raw %}{{{% endraw %}
     link: 'http://shoutem.github.io',
     text: 'This is the best',
@@ -249,7 +249,7 @@ import { NavigationBar } from '@shoutem/ui'
       <Icon name="close" />
     </Button>
   )}
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   rightComponent={(
     <Button styleName="clear">
       <Text>Post</Text>
@@ -269,7 +269,7 @@ import { NavigationBar } from '@shoutem/ui'
       <Text>Cancel</Text>
     </Button>
   )}
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   rightComponent={(
     <Button>
       <Text>Done</Text>
@@ -289,7 +289,7 @@ import { NavigationBar } from '@shoutem/ui'
       <Text>Cancel</Text>
     </Button>
   )}
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   rightComponent={(
     <Button styleName="muted">
       <Text>Done</Text>
@@ -298,15 +298,15 @@ import { NavigationBar } from '@shoutem/ui'
 />
 ```
 
-### Navbar / On primary color / back + share
-![Navbar / On primary color / back + share example]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-sublevel-action-no-border-copy@2x.png "Navbar / On primary color / back + share"){:.docs-component-image}
+### Navbar (Sublevel) + Share + Showing Background Color
+![Navbar (Sublevel) + Share + Showing Background Color]({{ site.url }}/img/ui-toolkit/navigationbar/navbar-sublevel-action-no-border-copy@2x.png "Navbar / On primary color / back + share"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX
 <NavigationBar
   styleName="clear"
   hasHistory
-  title="TITLE"
+  centerComponent={<Title>TITLE</Title>}
   share={% raw %}{{{% endraw %}
     link: 'http://shoutem.github.io',
     text: 'This is the best',
@@ -353,7 +353,7 @@ This `NavigationBar` and `CardStack` components provide simpler API for navigati
 
 * **clear**: sets the `Text` color to white and background colors to transparent
 * **fade**: sets the `Text` color to white and applies linear gradient to background
-* **no-border**: removes the bottom border 
+* **no-border**: removes the bottom border
 
 #### Style
 
@@ -362,10 +362,10 @@ This `NavigationBar` and `CardStack` components provide simpler API for navigati
 
 * **container**
   - Style prop for `View` that holds all components within `NavigationBar`
-  
+
 * **componentsContainer**
   - Style prop for `View` container that holds `leftComponent`, `centerComponent` and `rightComponent` objects
-  
+
 * **leftComponent**
   - Style applied to left Navigation component
 

--- a/docs/ui-toolkit/components/_posts/1970-01-04-DropDownMenu.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-04-DropDownMenu.md
@@ -7,22 +7,22 @@ section: UI toolkit
 
 # DropDownMenu
 
-DropDownMenu is a full-screen contextual menu for displaying lists of items. 
+DropDownMenu is a full-screen contextual menu for displaying lists of items.
 
 ![DropDownMenu example]({{ site.url }}/img/ui-toolkit/dropdownmenu/drop_down_menu@2x.png "DropDownMenu"){:.docs-component-image}
 
 ## API
 
 #### Props
- 
+
 * **onOptionSelected(option: object)**: function  
   - Called after tapping an option from menu, with all Props from that option passed to the function
 
 * **options**: array  
   - Array of options that are rendered as `Button`s within `ListView`
 
-* **selectedOption**: any 
-  - Sets pre-selected `option` from `options` array
+* **selectedOption**: any
+  - Sets which `option` from the `options` array is selected by default
 
 * **titleProperty**: string
   - Attribute that defines what `key` from `options` Prop will be used to render option Titles in Dropdown menu
@@ -44,7 +44,7 @@ DropDownMenu is a full-screen contextual menu for displaying lists of items.
 
 * **modalItem**
   - Style prop that holds single item (row) in `ListView`
- 
+
 * **selectedOption**
   - Style prop for a dropdown `Button` that opens a full-screen contextual menu and represents currently selected option
 

--- a/docs/ui-toolkit/components/_posts/1970-01-05-ListView.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-05-ListView.md
@@ -5,7 +5,7 @@ title: ListView
 section: UI toolkit
 ---
 
-# ListView 
+# ListView
 
 ListView component is a base component used to render Lists of items. This component is also used by GridView to create Grid-like menu structures.  
 
@@ -25,11 +25,11 @@ ListView component is a base component used to render Lists of items. This compo
   - Prop that defines whether the ListView should render loading spinner (to indicate it's still loading data) or actual items (when the data is successfully loaded)
 
 * **onLoadMore()**: function  
-  - Called when the ListView is scrolled all the way to the bottom of the first page. 
+  - Called when the ListView is scrolled all the way to the bottom of the first page.
   - In this function you should update `data` array (state) with additional items
 
 * **onRefresh()**: function  
-  - Called when the ListView is pulled down, triggering the refresh action. 
+  - Called when the ListView is pulled down, triggering the refresh action.
   - In this function you should update `data` array (state) with new items
   - If this function is declared, the Component will be considered refreshable
 
@@ -38,7 +38,7 @@ ListView component is a base component used to render Lists of items. This compo
 
 * **renderFooter()**: function  
   - Function that renders the Footer content
- 
+
 * **renderHeader()**: function  
   - Function that renders the Header content
 
@@ -47,7 +47,7 @@ ListView component is a base component used to render Lists of items. This compo
 
 #### Style
 
-* **list** 
+* **list**
   - these Props are passed to Style Prop of underlying React-Native `ListView` component  
 
 * **listContent**
@@ -55,7 +55,7 @@ ListView component is a base component used to render Lists of items. This compo
 
 * **loadMoreSpinner**
   - these Props are passed to Style Prop of the `Spinner` component that appears during initial content loading  
-     
+
 * **refreshControl**
   - these Props are passed to Style Prop of the `RefreshControl` component.  
   - You can also define `refreshControl.tintColor` prop in this Style, which is passed to the `tintColor` prop of the `RefreshControl` component.
@@ -72,11 +72,11 @@ ListView component is a base component used to render Lists of items. This compo
       restaurants: [{
         "name": "Gaspar Brasserie",
         "address": "185 Sutter St, San Francisco, CA 94109",
-        "image": { "url": "https://shoutem.github.io/restaurants/restaurant-1.jpg" },
+        "image": { "url": "{{site.url}}/static/getting-started/restaurant-1.jpg" },
       }, {
         "name": "Chalk Point Kitchen",
         "address": "527 Broome St, New York, NY 10013",
-        "image": { "url": "https://shoutem.github.io/restaurants/restaurant-2.jpg" },
+        "image": { "url": "{{site.url}}/static/getting-started/restaurant-2.jpg" },
       }],
     }
   }

--- a/docs/ui-toolkit/components/_posts/1970-01-06-GridView.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-06-GridView.md
@@ -32,8 +32,8 @@ The main idea behind this approach is to allow developers to have a variable num
   - **data**: *array* containing all items.
   - **columns**: *number* defining number of columns in grid.
   - **getColumnSpan**: *function* (optional) returns the column span of a single element. Each element has a span of 1 by default.
-  - **returns** an array of rows, where each row is an array of data elements.
-  
+  - returns an array of rows, where each row is an array of data elements.
+
 ## Example
 
 ![GridView (GridRow) example]({{ site.url }}/img/ui-toolkit/gridview/gridview-example.png "Grid View"){:.docs-component-image}
@@ -48,21 +48,21 @@ The main idea behind this approach is to allow developers to have a variable num
       restaurants: [{
         "name": "Gaspar Brasserie",
         "address": "185 Sutter St, San Francisco, CA 94109",
-        "image": { "url": "https://shoutem.github.io/restaurants/restaurant-1.jpg" },
+        "image": { "url": "{{site.url}}/static/getting-started/restaurant-1.jpg" },
       }, {
         "name": "Chalk Point Kitchen",
         "address": "527 Broome St, New York, NY 10013",
-        "image": { "url": "https://shoutem.github.io/restaurants/restaurant-2.jpg" },
+        "image": { "url": "{{site.url}}/static/getting-started/restaurant-2.jpg" },
       }, {
         "name": "Gaspar Brasserie",
         "address": "185 Sutter St, San Francisco, CA 94109",
-        "image": { "url": "https://shoutem.github.io/restaurants/restaurant-1.jpg" },
+        "image": { "url": "{{site.url}}/static/getting-started/restaurant-3.jpg" },
       }],
     }
   }
 
   renderRow(rowData, sectionId, index) {
-    // rowData contains grouped data for one row, 
+    // rowData contains grouped data for one row,
     // so we need to remap it into cells and pass to GridRow
 
     if (index === '0') {

--- a/docs/ui-toolkit/components/_posts/1970-01-07-Cards.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-07-Cards.md
@@ -15,8 +15,8 @@ Cards have become very popular in recent years. They are useful when displaying 
 
 #### Props
 
-* `Card` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `Card` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 * `Card` component doesn't have specific Style names, however the `View` component nested under `Card` can use the following Style name:
@@ -83,4 +83,3 @@ Cards have become very popular in recent years. They are useful when displaying 
   </View>
 </Card>
 ```
-

--- a/docs/ui-toolkit/components/_posts/1970-01-08-Dividers.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-08-Dividers.md
@@ -15,8 +15,8 @@ Dividers are components used to add space or any other separator between other c
 
 #### Props
 
-* `Divider` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `Divider` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 

--- a/docs/ui-toolkit/components/_posts/1970-01-09-Rows.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-09-Rows.md
@@ -15,16 +15,16 @@ section: UI toolkit
 
 #### Props
 
-* `Row` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `Row` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names  
-  
+
 * **small**: sets the fixed height of Row to 65px  
 * Nested components can also use these Style names:  
   * **disclosure**: applicable only for `Icon` components within `Row`. Pulls the icon to the right, and sets opacity to 50%  
   * **notification-dot**: applicable only for `View` components within  `Row`. Pulls the notification dot to the left of the content  
-  * **right-icon**: applicable only for `Button` components within `Row` 
+  * **right-icon**: applicable only for `Button` components within `Row`
   * **top**: applicable to any component nested within `Row`. Positions the component with `top` style to the beginning of `Row` component
   * **vertical**: applicable only for `View` components within `Row`. Adds a bottom margin below each `View` in `Row`
 
@@ -48,7 +48,7 @@ section: UI toolkit
 <Row styleName="small">
   <Image
     styleName="small-avatar"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-9.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-9.png' }}
   />
   <Text>Add comment</Text>
 </Row>
@@ -60,7 +60,7 @@ section: UI toolkit
 #### JSX Declaration
 ```JSX
 <Row styleName="small">
-  <Icon name="star" />
+  <Icon name="add-to-favorites" />
   <Text>Add to favorites</Text>
 </Row>
 ```
@@ -76,7 +76,7 @@ section: UI toolkit
     <Icon styleName="disclosure" name="right-arrow" />
 </Row>
 ```
-  
+
 ### Small list item + Icon + Description
 ![Small list item + Icon + Description Row example]({{ site.url }}/img/ui-toolkit/rows/small-list-item-icon-description@2x.png "Small list item + Icon + Description"){:.docs-component-image}
 
@@ -100,11 +100,11 @@ section: UI toolkit
 <Row>
   <Image
     styleName="small-avatar top"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-11.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-11.png' }}
   />
   <View styleName="vertical">
     <View styleName="horizontal space-between">
-      <Subtitle styleName="">Dustin Malone</Subtitle>
+      <Subtitle>Dustin Malone</Subtitle>
       <Caption>20 minutes ago</Caption>
     </View>
     <Text styleName="multiline">Banjo tote bag bicycle rights, High Life sartorial cray craft beer whatever street art fap. Hashtag typewriter banh mi, squid keffiyeh High.</Text>
@@ -120,7 +120,7 @@ section: UI toolkit
 <Row>
   <Image
     styleName="small rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-10.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-10.png' }}
   />
   <Subtitle styleName="top">Portland ugh fashion axe Helvetica, YOLO Echo Park Austin gastropub roof party.</Subtitle>
 </Row>
@@ -134,7 +134,7 @@ section: UI toolkit
 <Row>
   <Image
     styleName="small rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-6.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-6.png' }}
   />
   <View styleName="vertical stretch space-between">
     <Subtitle>Fact Check: Wisconsin Music, Film & Photography Debate</Subtitle>
@@ -151,7 +151,7 @@ section: UI toolkit
 <Row>
   <Image
     styleName="small rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
   />
   <View styleName="vertical stretch space-between">
     <Subtitle>Wilco Cover David Bowie&#39;s "Space Oddity"</Subtitle>
@@ -169,7 +169,7 @@ section: UI toolkit
 <Row>
   <Image
     styleName="small rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-11.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-11.png' }}
   />
   <View styleName="vertical stretch space-between">
     <Subtitle>Family Safari Vacation To The Home Of The Gods</Subtitle>
@@ -191,7 +191,7 @@ section: UI toolkit
   <View styleName="notification-dot" />
   <Image
     styleName="small rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-2.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-2.png' }}
   />
   <View styleName="vertical stretch space-between">
     <Subtitle>Fact Check: Wisconsin Music, Film & Photography Debate</Subtitle>
@@ -208,7 +208,7 @@ section: UI toolkit
 <Row>
   <Image
     styleName="medium rounded-corners"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-1.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-1.png' }}
   />
   <View styleName="vertical stretch space-between">
     <Subtitle>Take A Romantic Break In A Boutique Hotel</Subtitle>

--- a/docs/ui-toolkit/components/_posts/1970-01-10-Tiles.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-10-Tiles.md
@@ -15,8 +15,8 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 
 #### Props
 
-* Tile component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* Tile component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 
@@ -36,7 +36,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 <Tile styleName="small clear">
   <Image
     styleName="medium-square"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-12.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-12.png' }}
   />
   <View styleName="content">
     <Subtitle numberOfLines={2}>When The Morning Dawns - DJ Silver Sample Album</Subtitle>
@@ -45,7 +45,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 </Tile>
 ```
 
-### Tile + Icon
+### Tile + Play Icon
 ![Tile + Icon example]({{ site.url }}/img/ui-toolkit/tiles/tile-icon@2x.png "Tile + Icon"){:.docs-component-image}
 
 #### JSX Declaration
@@ -53,7 +53,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 <Tile styleName="small clear">
   <Image
     styleName="medium-square"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-2.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-2.png' }}
   >
     <Overlay styleName="rounded-small">
       <Icon name="play" />
@@ -73,7 +73,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="featured"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-4.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-4.png' }}
 >
   <Tile>
     <Title styleName="md-gutter-bottom">MIKE PATTON TEAMING WITH JOHN KAADA FOR COLLAB ALBUM BACTERIA CULT</Title>
@@ -89,7 +89,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="featured"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-11.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-11.png' }}
 >
   <Tile>
     <Overlay><Heading>-20%</Heading></Overlay>
@@ -101,14 +101,14 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 </Image>
 ```
 
-### Large (featured) tile + Button 
+### Large (featured) tile + Button
 ![Large (featured) tile + Button Tile example]({{ site.url }}/img/ui-toolkit/tiles/large-tile-button@2x.png "Large Tile + Button"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX
 <Image
   styleName="featured"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-9.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-9.png' }}
 >
   <Tile>
     <Title>MIKE PATTON TEAMING WITH JOHN KAADA</Title>
@@ -127,7 +127,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 <Tile>
   <Image
     styleName="large-banner"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-5.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-5.png' }}
   />
   <View styleName="content">
     <Title>MAUI BY AIR THE BEST WAY AROUND THE ISLAND</Title>
@@ -147,7 +147,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 <Tile>
   <Image
     styleName="large-banner"
-    source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-7.png' }}
+    source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-7.png' }}
   >
     <Overlay styleName="rounded-small">
       <Icon name="play" />
@@ -170,7 +170,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-banner"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
 >
   <Tile>
     <Title styleName="md-gutter-bottom">SMOKED SALMON, CLASSIC CONDIMENTS, BRIOCHE</Title>
@@ -188,7 +188,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-banner"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
 >
   <Tile>
     <View styleName="actions">
@@ -207,7 +207,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-square"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
 >
   <Tile>
     <Title styleName="md-gutter-bottom">SMOKED SALMON, CLASSIC CONDIMENTS, BRIOCHE</Title>
@@ -225,7 +225,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-square"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-9.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-9.png' }}
 >
   <Tile>
     <Title>MIKE PATTON TEAMING WITH JOHN KAADA</Title>
@@ -243,7 +243,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-square"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-11.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-11.png' }}
 >
   <Tile>
     <Overlay><Heading>-20%</Heading></Overlay>
@@ -262,7 +262,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-portrait"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
 >
   <Tile>
     <Title styleName="md-gutter-bottom">SMOKED SALMON, CLASSIC CONDIMENTS, BRIOCHE</Title>
@@ -298,7 +298,7 @@ Tiles are a convenient way to display homogeneous content. They are often used i
 ```JSX
 <Image
   styleName="large-portrait"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-11.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-11.png' }}
 >
   <Tile>
     <Overlay><Heading>-20%</Heading></Overlay>

--- a/docs/ui-toolkit/components/_posts/1970-01-12-Buttons.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-12-Buttons.md
@@ -13,8 +13,8 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 
 #### Props
 
-* `Button` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `TouchableOpacity` component supports. For full list of available props, visit 
-[React Native TouchableOpacity component documentation](https://facebook.github.io/react-native/docs/touchableopacity.html "React Native TouchableOpacity component documentation")  
+* `Button` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `TouchableOpacity` component supports. For full list of available props, visit
+[React Native TouchableOpacity component documentation](https://facebook.github.io/react-native/docs/touchableopacity.html "React Native TouchableOpacity component documentation").
 
 #### Style names
 
@@ -30,7 +30,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 
 #### Style
 * **underlayColor**: the color that will show through when the `Button` is pressed
-* Also, supports every `Style` prop that the standard React Native `View` component supports 
+* Also, supports every `Style` prop that the standard React Native `View` component supports
 
 ## Examples
 
@@ -81,7 +81,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 
 #### JSX Declaration
 ```JSX
-<View styleName="horizontal flexible">
+<View styleName="horizontal">
   <Button styleName="confirmation">
     <Text>REMOVE</Text>
   </Button>
@@ -102,7 +102,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 </Button>
 ```  
 
-### Button / Navbar
+### Icon Button
 ![Button / Navbar example]({{ site.url }}/img/ui-toolkit/buttons/button-navbar@2x.png "Button / Navbar"){:.docs-component-image}
 
 #### JSX Declaration
@@ -123,7 +123,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 </Button>
 ```  
 
-### Button / Full width - Normal
+### Button / Full width - Muted
 ![Button / Full width - Normal example]({{ site.url }}/img/ui-toolkit/buttons/button-full-width-normal@2x.png "Button / Full width - Normal"){:.docs-component-image}
 
 #### JSX Declaration
@@ -140,8 +140,8 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 </View>
 ```  
 
-### Button / Full width - Active (Feed)
-![Button / Full width - Active (Feed) example]({{ site.url }}/img/ui-toolkit/buttons/button-full-width-active@2x.png "Button / Full width - Active (Feed)"){:.docs-component-image}
+### Button / Full width - Active
+![Button / Full width - Active example]({{ site.url }}/img/ui-toolkit/buttons/button-full-width-active@2x.png "Button / Full width - Active (Feed)"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX

--- a/docs/ui-toolkit/components/_posts/1970-01-13-Image.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-13-Image.md
@@ -15,8 +15,8 @@ This document covers `Image` component and Image size style names available in S
 
 #### Props
 
-* `Image` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `Image` component supports. For full list of available props, visit 
-[React Native Image component documentation](https://facebook.github.io/react-native/docs/image.html "React Native Image component documentation")  
+* `Image` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `Image` component supports. For full list of available props, visit
+[React Native Image component documentation](https://facebook.github.io/react-native/docs/image.html "React Native Image component documentation").
 
 
 #### Style names
@@ -33,12 +33,12 @@ For most of available `Image` style names, Image dimensions are scaled depending
 * **medium**: width: `145px` x height: `92px`
 * **medium-wide**: width: `(180/375)` height: `window.width x 85px`
 * **medium-square**: width: `145px` height: `145px`
-* **rounded-corners**: defines rounded corners, as defined in Theme 
+* **rounded-corners**: defines rounded corners, as defined in Theme
 * **small-avatar**: rounded image, 25px radius
 * **small**: width: `65px` height: `65px`
 
 #### Style
-* Supports every `Style` prop that the standard React Native `Image` component supports 
+* Supports every `Style` prop that the standard React Native `Image` component supports
 
 
 ## Examples
@@ -50,10 +50,10 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="small"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
-  
+
 ### List video thumbnail (145x92)
 ![List video thumbnail (145x92) example]({{ site.url }}/img/ui-toolkit/image-sizes/list-video-thumbnail-145-x-92@2x.png "List video thumbnail (145x92)"){:.docs-component-image}
 
@@ -61,10 +61,10 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="medium"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
-  
+
 ### Card image thumbnail (180x85)
 ![Card image thumbnail (180x85) example]({{ site.url }}/img/ui-toolkit/image-sizes/card-image-thumbnail-180-85@2x.png "Card image thumbnail (180x85)"){:.docs-component-image}
 
@@ -72,7 +72,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="medium-wide"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```    
 
@@ -83,7 +83,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="small-avatar"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```      
 
@@ -94,7 +94,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="medium-avatar"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
 
@@ -105,7 +105,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="medium-square"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
 
@@ -116,7 +116,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="large-banner"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
 
@@ -127,7 +127,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="featured"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
 
@@ -138,7 +138,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="large-portrait"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```   
 
@@ -149,7 +149,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="large"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  
 
@@ -160,7 +160,7 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="large-wide"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```   
 
@@ -171,6 +171,6 @@ For most of available `Image` style names, Image dimensions are scaled depending
 ```JSX
 <Image
   styleName="large-square"
-  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}} />
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png'}}
 />
 ```  

--- a/docs/ui-toolkit/components/_posts/1970-01-15-View.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-15-View.md
@@ -13,15 +13,15 @@ View is a React Native's `View` with additional (flexbox) styling styleNames ava
 
 #### Props
 
-* `View` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `View` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 
-* **fill-parent**: `View` becomes absolutely positioned and takes all available space of its parent container 
+* **fill-parent**: `View` becomes absolutely positioned and takes all available space of its parent container
 * **horizontal**: Places all items in a row
   * **h-center**: Centers item in a row horizontally
-  * **h-start**: Places item to the horizontal start of row 
+  * **h-start**: Places item to the horizontal start of row
   * **h-end**: Places item to the horizontal end of row
   * **v-center**: Centers all items in a row vertically
   * **v-start**: Places item to the vertical start of row
@@ -38,7 +38,7 @@ View is a React Native's `View` with additional (flexbox) styling styleNames ava
 * **wrap**: Defines whether the flexible items should wrap
 
 #### Style
-* Supports every `Style` prop that the standard React Native `View` component supports 
+* Supports every `Style` prop that the standard React Native `View` component supports
 
 ## Examples
 
@@ -51,4 +51,3 @@ View is a React Native's `View` with additional (flexbox) styling styleNames ava
     {...}
 </View>
 ```  
-

--- a/docs/ui-toolkit/components/_posts/1970-01-16-Screen.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-16-Screen.md
@@ -8,13 +8,13 @@ section: UI toolkit
 # Screen
 
 Screen is a React Native's `View` with additional background color defined in Theme (defaults to gray).
-  
+
 ## API
 
 #### Props
 
-* `Screen` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `Screen` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 
@@ -22,7 +22,7 @@ Screen is a React Native's `View` with additional background color defined in Th
 * **paper**: Applies a `Light` color, as defined in Theme
 
 #### Style
-* Supports every `Style` prop that the standard React Native `View` component supports 
+* Supports every `Style` prop that the standard React Native `View` component supports
 
 ## Examples
 

--- a/docs/ui-toolkit/components/_posts/1970-01-18-Headers.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-18-Headers.md
@@ -5,7 +5,7 @@ title: Headers
 section: UI toolkit
 ---
 
-# Headers 
+# Headers
 
 Headers are Tile variations - Headers do not have `Image` as parent component of `Tile` component.
 
@@ -25,7 +25,7 @@ See [Tiles]({{ site.url }}/docs/ui-toolkit/components/tiles) for API reference.
   <Caption>Sophia Jackson        2 hours ago</Caption>
 </Tile>
 ```
-  
+
 ### Header / Shop item
 ![Header / Shop item example]({{ site.url }}/img/ui-toolkit/headers/header-shop-item@2x.png "Header / shop item"){:.docs-component-image}
 
@@ -39,7 +39,7 @@ See [Tiles]({{ site.url }}/docs/ui-toolkit/components/tiles) for API reference.
   <Button styleName="dark md-gutter-top"><Icon name="cart" /><Text>ADD TO BASKET</Text></Button>
 </Tile>
 ```
-  
+
 ### Header / Deals item
 ![Header / Deals item example]({{ site.url }}/img/ui-toolkit/headers/header-deals-item@2x.png "Large Tile + Button"){:.docs-component-image}
 

--- a/docs/ui-toolkit/components/_posts/1970-01-19-Overlay.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-19-Overlay.md
@@ -5,7 +5,7 @@ title: Overlay
 section: UI toolkit
 ---
 
-# Overlay 
+# Overlay
 
 `Overlay` provides a convenient way to place content over `Image`, through semi-transparent background.
 
@@ -15,8 +15,8 @@ section: UI toolkit
 
 #### Props
 
-* `Overlay` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit 
-[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation")  
+* `Overlay` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `View` component supports. For full list of available props, visit
+[React Native View component documentation](https://facebook.github.io/react-native/docs/view.html "React Native View component documentation").
 
 #### Style names
 
@@ -27,7 +27,7 @@ section: UI toolkit
 * **solid-dark**: sets the `backgroundColor` to `Darker` variant, while keeping the text color set to `Light` variant, as defined in Theme
 
 #### Style
-* Supports every `Style` prop that the standard React Native `View` component supports 
+* Supports every `Style` prop that the standard React Native `View` component supports
 
 
 ## Example
@@ -39,7 +39,7 @@ section: UI toolkit
 ```JSX
 <Image
   styleName="large-square"
-  source={% raw %}{{{% endraw %} uri: 'http://shoutem.github.io/img/ui-toolkit/examples/image-3.png' }}
+  source={% raw %}{{{% endraw %} uri: '{{site.url}}/img/ui-toolkit/examples/image-3.png' }}
 >
   <Tile>
     <Title styleName="md-gutter-bottom">SMOKED SALMON, CLASSIC CONDIMENTS, BRIOCHE</Title>
@@ -49,7 +49,7 @@ section: UI toolkit
   </Tile>
 </Image>
 ```
-  
+
 ### Solid (dark) overlay
 ![Solid (dark) overlay example]({{ site.url }}/img/ui-toolkit/headers/header-products-item@2x.png "Solid (dark) overlay example"){:.docs-component-image}
 
@@ -62,7 +62,3 @@ section: UI toolkit
   </Overlay>
 </Tile>
 ```
-    
-
-
-

--- a/docs/ui-toolkit/components/_posts/1970-01-20-Video.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-20-Video.md
@@ -7,8 +7,7 @@ section: UI toolkit
 
 # Video
 
-`Video` component can be used to render all types of video items.  
-It renders a Video based on the source type. If the source is `URL` to a web player, the video is displayed in a `WebView`. If the source is a video stream URL, a `video` `HTML` element is displayed in the `WebView`. The component does not support playback of local video files.
+`Video` component can be used to render all types of video items. It renders a Video based on the source type. If the source is `URL` to a web player, the video is displayed in a `WebView`. If the source is a video stream URL, a `video` `HTML` element is displayed in the `WebView`. The component does not support playback of local video files.
 
 ![Video example]({{ site.url }}/img/ui-toolkit/video/video_player@2x.png "Video"){:.docs-component-image}
 
@@ -21,7 +20,7 @@ It renders a Video based on the source type. If the source is `URL` to a web pla
 
 * **height**: number
   - Prop that sets the height of the container where the video preview thumbnail will be rendered
-   
+
 * **width**: number
   - Prop that sets the width of the container where the video preview thumbnail will be rendered
 
@@ -47,6 +46,3 @@ It renders a Video based on the source type. If the source is `URL` to a web pla
     width={300}
 />
 ```
-
-
-

--- a/docs/ui-toolkit/components/_posts/1970-01-23-TextInput.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-23-TextInput.md
@@ -7,14 +7,14 @@ section: UI toolkit
 
 # TextInput
 
-`TextInput` component is used for inputting text into the application using keyboard. 
+`TextInput` component is used for inputting text into the application using keyboard.
 
 ## API
 
 #### Props
 
-* `TextInput` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `TextInput` component supports. For full list of available props, visit 
-[React Native TextInput component documentation](https://facebook.github.io/react-native/docs/textinput.html "React Native TextInput component documentation")  
+* `TextInput` component doesn't have specific (custom) Props, however, it supports every prop that the standard React Native `TextInput` component supports. For full list of available props, visit
+[React Native TextInput component documentation](https://facebook.github.io/react-native/docs/textinput.html "React Native TextInput component documentation").
 
 #### Style names
 
@@ -26,29 +26,29 @@ section: UI toolkit
   - defines the placeholder text color
 * **selectionColor**:  
   - The highlight color of the text input (and the cursor color on iOS)
-* Also, supports every `Style` prop that the standard React Native `TextInput` component supports 
+* Also, supports every `Style` prop that the standard React Native `TextInput` component supports
 
 ## Examples
 
-### Input / Placeholder text 
+### Input / Placeholder text
 ![Input / Placeholder text  example]({{ site.url }}/img/ui-toolkit/inputs/input-placeholder@2x.png "Input / Placeholder text"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX
-<TextInput 
+<TextInput
   placeholder={'Username or email'}
-  onChangeText={...} 
+  onChangeText={...}
 />
 ```
 
-### Input / With text 
+### Input / With text
 ![Input / With text  example]({{ site.url }}/img/ui-toolkit/inputs/input-with-value@2x.png "Input / With text"){:.docs-component-image}
 
 #### JSX Declaration
 ```JSX
-<TextInput 
+<TextInput
   defaultValue={'Username or email'}
-  onChangeText={...} 
+  onChangeText={...}
 />
 ```
 
@@ -57,8 +57,8 @@ section: UI toolkit
 
 #### JSX Declaration
 ```JSX
-<TextInput 
-  placeholder={'SecurePasswordGoesHere'}
+<TextInput
+  placeholder={'Password'}
   secureTextEntry
 />
 ```


### PR DESCRIPTION
Made any and all clarity editing possible.

Changed all full image URL's to:
`{{site.url}}/rest/of/the/url`

As far as I understand, we're able to switch from `http` to `https`. If possible, this should be done, otherwise all of these examples will fail to display on iOS emulators since they utilise `http`.