### PR TITLE
Fixed 'raw' 'endraw' for style

### DIFF
--- a/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
+++ b/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
@@ -298,7 +298,7 @@ export default class QRReaderScreen extends Component {
     return (
       <Camera
         onBarCodeRead={_.debounce(this.onBarCodeRead, 1000, { leading: true, trailing: false })}
-        style={{ flex: 1 }}
+        style={% raw %}{{{% endraw %} flex: 1 }}
       />
     );
   }


### PR DESCRIPTION
A style that was using double curly braces wasn't encased in `{% raw %} {% endraw %}`. This hotfix fixes that.