### PR TITLE
Writing a Theme updated to work with new CLI files.

### DIFF
--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -439,6 +439,9 @@ After that, you can _push_ your extension to update the changes you've made on t
 
 However, you won't be able to preview these changes in the Builder or using the **Shoutem Preview** app. This is because fonts are linked into the binary of the app, while the Builder and Shoutem Preview app previews have their own, unchangeable binary and only preview JavaScript bundle changes. So to be able to preview this you'll have to set up your local development environment so the custom font is linked into the local binary. You can find out how to do that [here]({{ site.url }}/docs/extensions/tutorials/setting-local-environment).
 
+> #### Note
+> If your theme extension is already inside a _cloned_ app for local development, you will have to re-clone the app. Make sure you push all your local changes before cloning again!
+
 Here you can see the difference between `Noto Serif` (left), a font included in our default theme, and our example custom font `Roboto Regular` (right):
 
 <p class="image">

--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -71,7 +71,7 @@ The `showcase` property, which is empty, is an array of images and videos that w
 ],
 ```
 
-As stated above, you can add videos as well to show off your theme, you can see an example of that with our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets).
+As stated above, you can add videos as well to show off your theme.
 
 The CLI also made sure that `app/extension.js` handles the newly created theme:
 
@@ -144,7 +144,7 @@ Now check the `Customize theme` tab.
 <img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-no_picker.png'/>
 </p>
 
-Here the app owner can customize your theme through theme variables. These variables can be found in `server/themes/restaurantVariables.json` and they're a copy of the [Rubicon theme variables](https://github.com/shoutem/extensions/blob/master/shoutem-rubicon-theme/server/themeVariables.json).
+Here the app owner can customize your theme through theme variables. These variables can be found in `server/themes/restaurantVariables.json` and they're a copy of the [Rubicon theme variables](https://github.com/shoutem/extensions/blob/master/shoutem-rubicon-theme/server/primeThemeVariables.json).
 
 ## How Themes Work
 
@@ -395,7 +395,7 @@ Check `Customize theme` under the `Style` tab. You can see the `Restaurants` sec
 
 ## Adding a Custom Font
 
-In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme]("https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts") extension. For the purpose of this tutorial, use a custom [Roboto font](https://www.fontsquirrel.com/fonts/roboto) for you to use.
+In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts) extension. For the purpose of this tutorial, use a custom [Roboto font](https://www.fontsquirrel.com/fonts/roboto) for you to use.
 
 These fonts also have to be linked into the app's binary as [assets](https://github.com/rnpm/rnpm#advanced-usage) using [`rnmp`](https://github.com/rnpm/rnpm). You do this by adding the following to your extension's `app/package.json` file:
 
@@ -467,14 +467,7 @@ To do this, simply click on the icon you want to change to open the modal window
 
 After selecting `My icons` you can see the list of icons you uploaded for that specific app. The disadvantage of using this method is that the icon will only exist for that app, while your extension might be installed in multiple apps.
 
-The `Theme icons` category refers to the icons from different themes. You can see that when comparing the icons that the [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons) (left) offers to the ones that the [Arno theme](https://github.com/shoutem/extensions/tree/master/shoutem-arno-theme/server/assets/icons) (right) offers:
-
-<p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/icon-theme-comparison.png'/>
-</p>
-
-> #### Note
-> These are not all the icons that are available. To see the full list of icons, check these links to the [Rubicon](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons) and [Arno](https://github.com/shoutem/extensions/tree/master/shoutem-arno-theme/server/assets/icons) themes.
+The `Theme icons` category refers to the icons from different themes. You can find out which icons are offered in our Rubicon theme [here](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons).
 
 ### 2) Adding an icon to your custom theme
 
@@ -485,7 +478,7 @@ $ cd server
 $ mkdir assets/icons
 ```
 
-And then add your custom icon to it. The reason we use the server folder is because this is utilized by the server side, i.e. the Builder. You can see this structure in our [Rubicon theme]("https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons").
+And then add your custom icon to it. The reason we use the server folder is because this is utilized by the server side, i.e. the Builder. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons).
 
 The icon you add should be a `.png` and `48x48` resolution. In this example tutorial we'll use the previously mentioned restaurant related icon, a plate and utensils.
 
@@ -506,7 +499,7 @@ After creating the directory and adding your custom icon to it you have to modif
 }],
 ```
 
-You can see this in our [Rubicon theme]("https://github.com/shoutem/extensions/blob/master/shoutem-rubicon-theme/extension.json").
+You can see this in our [Rubicon theme](https://github.com/shoutem/extensions/blob/master/shoutem-rubicon-theme/extension.json).
 
 Now you can simply _push_ to update your extension on Shoutem and once you open your Restaurants app in the Builder and check the Main navigation icons you can see your new icon under the `Theme icons` category.
 
@@ -514,4 +507,4 @@ Now you can simply _push_ to update your extension on Shoutem and once you open 
 <img src='{{ site.url }}/img/tutorials/settings-theme/custom-icon.png'/>
 </p>
 
-The other icons you see are a copy of the icons provided by the [Rubicon theme]("https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons"), this is because when you create a custom theme you're making a copy of Rubicon.
+The other icons you see are a copy of the icons provided by the [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons), because, like we said, when you create a custom theme you're making a copy of Rubicon.

--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -395,7 +395,7 @@ Check `Customize theme` under the `Style` tab. You can see the `Restaurants` sec
 
 ## Adding a Custom Font
 
-In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts) extension. For the purpose of this tutorial, you can use the [Roboto font](https://www.fontsquirrel.com/fonts/roboto).
+In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts) extension. For the purpose of this tutorial you can use the [Roboto font](https://www.fontsquirrel.com/fonts/roboto).
 
 These fonts also have to be linked into the app's binary as [assets](https://github.com/rnpm/rnpm#advanced-usage) using [`rnmp`](https://github.com/rnpm/rnpm). You do this by adding the following to your extension's `app/package.json` file:
 

--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -395,7 +395,7 @@ Check `Customize theme` under the `Style` tab. You can see the `Restaurants` sec
 
 ## Adding a Custom Font
 
-In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts) extension. For the purpose of this tutorial, use a custom [Roboto font](https://www.fontsquirrel.com/fonts/roboto) for you to use.
+In order to add a custom font to a theme, you'll have to add a `fonts` folder to your extension's `app` folder and add your custom fonts to it in `.TTF` format. You can see this structure in our [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/app/fonts) extension. For the purpose of this tutorial, you can use the [Roboto font](https://www.fontsquirrel.com/fonts/roboto).
 
 These fonts also have to be linked into the app's binary as [assets](https://github.com/rnpm/rnpm#advanced-usage) using [`rnmp`](https://github.com/rnpm/rnpm). You do this by adding the following to your extension's `app/package.json` file:
 

--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -104,7 +104,7 @@ export function ext(resourceName) {
 
 And that our public API, `app/index.js`, exports the newly created theme:
 
-```JavaScript{9}
+```JavaScript{8}
 #file: app/index.js
 // Reference for app/index.js can be found here:
 // http://shoutem.github.io/docs/extensions/reference/extension-exports
@@ -113,7 +113,6 @@ import reducer from './reducer';
 import * as extension from './extension.js';
 
 export const screens = extension.screens;
-
 export const themes = extension.themes;
 
 export { reducer };
@@ -166,7 +165,7 @@ From the docs on how to use `@shoutem/theme`, in order to support the theme, we 
 
 We didn't use `style`, but now we're going to use it from `this.props.style` in the `renderRow` method. Also, import `connectStyle` from `@shoutem/theme` to connect the component to the theme and assign a `name` to it.
 
-```JavaScript{18,48,57-58,90-92}
+```JavaScript{20,53,63-64,92-94}
 #file: app/screens/List.js
 import React, {
   Component
@@ -272,28 +271,38 @@ Ok, we've added style from theme to the component, but we haven't implemented th
 
 We created a theme file (`app/themes/restaurant.js`) with a Rubicon template. Since a Shoutem app can only have 1 theme applied at a time, it's a good practice to include styling rules for the components usually used in Shoutem extensions, such as the ones from `@shoutem/ui`.
 
-The theme file is huge and it won't be pasted here fully. Just search for the `export default` statement which exports theme functions. In _theme object_ (which is returned by _theme function_), add the agreed styling rules: _make titles bigger in restaurant rows and change the background color of subtitles to white, while changing the text color to black_.
+The theme file is **huge** and it won't be pasted into the code snippet here fully. Just search for the `export default` statement which exports theme functions. In `return`, add the agreed styling rules:
+  - make titles bigger in restaurant rows
+  - change the background color of subtitles to white
+  - change the subtitle color to black
 
-Add the following styling rules to the beginning of the exported object:
+Import the `ext` function and add the following styling rules to the beginning of the exported object:
 
-```JavaScript{1,6-14}
+```JavaScript{3,14-22}
 #file: app/themes/restaurant.js
+// other imports ...
+
 import { ext } from '../extension';
 
-// constants ...
+// exports and constants ...
 
-export default (variables = {}) => ({
-  [ext('List')]: {
-    title: {
-      fontSize: 25,
+export default (customVariables = {}) => {
+  const variables = {
+    ...defaultThemeVariables,
+    ...customVariables,
+  };
+
+  return _.merge({}, getTheme(variables), {
+    [ext('List')]: {
+      title: {
+        fontSize: 25,
+      },
+      subtitle: {
+        color: 'black',
+        backgroundColor: 'white'
+      }
     },
-    subtitle: {
-      color: 'black',
-      backgroundColor: 'white'
-    }
-  },
-
-  // the rest of the styling rules...
+    // the rest of the styling rules...
 })
 ```
 
@@ -350,22 +359,23 @@ The only thing left to do is to use this variable in the theme file. Again, sear
 
 ```JavaScript{11}
 #file: app/themes/restaurant.js
-import { ext } from '../const';
+export default (customVariables = {}) => {
+  const variables = {
+    ...defaultThemeVariables,
+    ...customVariables,
+  };
 
-// constants ...
-
-export default (variables = {}) => ({
-  [ext('List')]: {
-    title: {
-      fontSize: 15,
+  return _.merge({}, getTheme(variables), {
+    [ext('List')]: {
+      title: {
+        fontSize: 25,
+      },
+      subtitle: {
+        color: 'black',
+        backgroundColor: 'white'
+      }
     },
-    subtitle: {
-      color: variables.subtitleColor,
-      backgroundColor: 'white'
-    }
-  },
-
-  // the rest of the styling rules...
+    // the rest of the styling rules...
 })
 ```
 


### PR DESCRIPTION
Removed Arno references and fixed links to Rubicon theme.

Updated the code snippets to reflect the new `theme.js` file structure.

Added note for `Adding a Custom Font` section of the tutorial that prompts users to clone the app again.