### PR TITLE
Remove `shoutem link` reference.

### DIFF
--- a/docs/extensions/reference/_posts/1970-01-06-CLI.md
+++ b/docs/extensions/reference/_posts/1970-01-06-CLI.md
@@ -282,7 +282,7 @@ You can scan the QR code containing the app URL using **Shoutem Preview** app (a
 
 Upon reading the QR code, Shoutem Preview will connect to your computer and embed the JS code within itself. You can now see how your app behaves and feels on a real device without ever having to build or pull the native code. By default, `shoutem run` bundles the **release** build (See [Building your app for production](https://facebook.github.io/react-native/docs/running-on-device.html#building-your-app-for-production).
 
-`shoutem run --dev` If you want to debug your extensions using this method, you should first link them using `shoutem link` command and then use the `--dev` flag with `shoutem run`. This will create `debug` build. The app performance will be a bit slower, but this will allow you to use Chrome/Safari/Firefox debug tools.
+`shoutem run --dev` If you want to debug your extensions using this method, use the `--dev` flag with `shoutem run`. This will create `debug` build. The app performance will be a bit slower, but this will allow you to use Chrome/Safari/Firefox debug tools.
 
 `shoutem run --local` By default, React Native packager is tunneled through [ngrok]((https://ngrok.com/). Use `--local` flag if you are connected with your smartphone to the same network as your computer. This will allow Shoutem Preview app to fetch the JS bundle directly from your computer, which will reduce the delay in refreshing code changes. Also, your computer must be able to open `8081` port. This might require manual configuration of your computer's firewall settings.
 


### PR DESCRIPTION
Reference still included `shoutem link` in one instance. Now removed.