### PR TITLE
Fixed { ext } import in Using UI Toolkit docs

### DIFF
--- a/docs/extensions/my-first-extension/_posts/1970-01-05-UsingUIToolkit.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-05-UsingUIToolkit.md
@@ -115,7 +115,7 @@ import {
   TouchableOpacity
 } from 'react-native';
 import { navigateTo } from '@shoutem/core/navigation';
-import { ext } from '../extension';
+import { ext } from '../const';
 ```
 
 [Connect](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) `navigateTo` action creator to redux store.


### PR DESCRIPTION
Switched from
`import { ext } from '../extension';`
To
`import { ext } from '../const';`