### PR TITLE
Remove shortcut flag from ShellSession snippet

### DIFF
--- a/docs/extensions/tutorials/_posts/1970-01-04-WritingReactSettingsPage.md
+++ b/docs/extensions/tutorials/_posts/1970-01-04-WritingReactSettingsPage.md
@@ -32,7 +32,7 @@ cd {{ site.example.devName }}.html-hello-world
 And add the screen:
 
 ```ShellSession
-$ shoutem screen add Hello --shortcut Hello
+$ shoutem screen add Hello
 ? Screen name: Hello
 ? Create a shortcut (so that screen can be added through the Builder)? Yes
 ? Shortcut name: Hello


### PR DESCRIPTION
Removed `--shortcut` flag from a ShellSession snippet due to deprecation.