### PR TITLE
Correct style name from 'dark' to 'secondary'.

### DIFF
--- a/docs/ui-toolkit/components/_posts/1970-01-12-Buttons.md
+++ b/docs/ui-toolkit/components/_posts/1970-01-12-Buttons.md
@@ -22,7 +22,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 * **border**: applies `Border` color as defined in Theme
 * **clear**: removes the border around `Button` and sets `backgroundColor` to `Clear` color as defined in Theme
 * **confirmation**: sets the border around `Button` and applies a medium margin around  
-* **dark**: sets the text color to `Light` as defined in Theme, and background color to `Darker` as defined in Theme
+* **secondary**: sets the text color to `Light` as defined in Theme, and background color to `Darker` as defined in Theme
 * **full-width**: `Button` stretches to full width of the container
 * **muted**: sets the opacity of the `Icon` and `Text` components within `Button`to 50%
 * **stacked**: vertically stacks `Icon` and `Text` within `Button`
@@ -50,7 +50,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 
 #### JSX Declaration
 ```JSX
-<Button styleName="dark">
+<Button styleName="secondary">
   <Text>CHECK IN HERE</Text>
 </Button>
 ```  
@@ -71,7 +71,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
 
 #### JSX Declaration
 ```JSX
-<Button styleName="dark">
+<Button styleName="secondary">
   <Icon name="add-event" />
   <Text>ADD TO CALENDAR</Text>
 </Button>
@@ -87,7 +87,7 @@ Buttons are additionally styled [TouchableOpacity]({{ site.url }}/docs/ui-toolki
     <Text>REMOVE</Text>
   </Button>
 
-  <Button styleName="confirmation dark">
+  <Button styleName="confirmation secondary">
     <Text>UPDATE</Text>
   </Button>
 </View>


### PR DESCRIPTION
The 'dark' style has already been deprecated in favor of the 'secondary' style.