### PR TITLE
Create 'Modifying root app' docs.

### DIFF
--- a/_includes/sidebar-nav.html
+++ b/_includes/sidebar-nav.html
@@ -27,7 +27,7 @@
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/publish-your-app">Publish your app</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/connecting-to-api">Connecting to 3rd party API</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/installing-3rd-party-packages">Installing 3rd party packages</a></li>
-			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/modifying-root-app">Modifying root app</a></li>
+			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/modifying-native-project">Modifying native project</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/writing-a-theme">Writing a theme</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/screen-layouts">Screen layouts</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/using-localization">Localization</a></li>

--- a/_includes/sidebar-nav.html
+++ b/_includes/sidebar-nav.html
@@ -26,7 +26,8 @@
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/setting-local-environment">Local environment setup</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/publish-your-app">Publish your app</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/connecting-to-api">Connecting to 3rd party API</a></li>
-			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/installing-3rd-party-packages">Installing 3rd Party Packages</a></li>
+			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/installing-3rd-party-packages">Installing 3rd party packages</a></li>
+			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/modifying-root-app">Modifying root app</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/writing-a-theme">Writing a theme</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/screen-layouts">Screen layouts</a></li>
 			<li><a href="{{ site.baseurl }}/docs/extensions/tutorials/using-localization">Localization</a></li>

--- a/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
+++ b/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
@@ -14,7 +14,7 @@ This tutorial will show you how to install a 3rd party package into an extension
 
 ## 1) Installing a non-native Package
 
-A non-native package doesn't utilize native capabilities of the underlying device. Simply put, the package doesn't handle anything differently regardless of the fact it's being run on iOS or Android. When you finish this tutorial you'll have a functioning `swiper-extension`, like the one from our [extension examples](https://github.com/shoutem/extension-examples).
+A non-native package doesn't utilize native capabilities of the underlying device. Simply put, the package doesn't handle anything differently regardless of the fact it's being run on iOS or Android. When you finish this tutorial you'll have a functioning `swiper-extension`.
 
 ### Making an Extension
 
@@ -200,14 +200,14 @@ Success
 
 To make sure the native dependencies are linked, we'll have to make sure our custom postlink script is run by putting it in our `app/package.json` file. `rnpm`'s `postlink` command runs our `app/scripts/run.js` script that we'll explain afterwards.
 
-```json
+```json{8-12}
 #file: app/package.json
 {
   "name": "{{ site.example.devName }}.qr-reader-extension",
   "version": "0.0.1",
   "description": "An extension that scans QR codes and displays the encoded information to the user.",
   "dependencies": {
-    "react-native-camera": "^0.4.1"
+    "react-native-camera": "1.1.4"
   },
   "rnpm": {
     "commands": {
@@ -223,46 +223,17 @@ To make sure the native dependencies are linked, we'll have to make sure our cus
 Create a `scripts` directory and make the postlink script in it: `app/scripts/run.js`
 
 ```ShellSession
-$ cd app
-$ mkdir scripts
-$ cd scripts
-$ touch run.js
+$ touch app/scripts/run.js
 ```
 
-It's going to edit the `Info.plist` file and link the `react-native-camera` dependency for our app.
+Using the `react-native-link` helper method from the Shoutem platform's `@shoutem/build-tools`, we can easily link the package.
 
 ```javascript{1-21}
 #file: app/scripts/run.js
-const fs = require('fs-extra');
-const plist = require('plist');
+const { reactNativeLink } = require('@shoutem/build-tools');
 
-const infoPlistPath = './ios/ShoutemApp/Info.plist';
-const infoPlistFile = fs.readFileSync(infoPlistPath, 'utf8');
-const infoPlist = plist.parse(infoPlistFile);
-
-console.log('Adding camera and microphone permissions to Info.plist');
-infoPlist['NSCameraUsageDescription'] = 'App needs your camera to be able to scan QR codes';
-infoPlist['NSMicrophoneUsageDescription'] = 'App needs your microphone to be able to scan QR codes';
-fs.writeFileSync(infoPlistPath, plist.build(infoPlist));
-
-const exec = require('child_process').execSync;
-
-const dependenciesToLink = ['react-native-camera'];
-
-const command = 'node node_modules/react-native/local-cli/cli.js link';
-
-dependenciesToLink.forEach((dependency) => {
-  exec(`${command} ${dependency}`);
-});
+reactNativeLink('react-native-camera');
 ```
-
-Now let's explain the details regarding native dependency linking in `app/scripts/run.js`
-  - everything regarding `Info.plist` is added to notify the user that the app is using his camera
-  - `dependenciesToLink` is an array that stores all of our native dependencies, add more modules here to link them inside your app
-  - `command` uses the react-native-cli to link native dependencies
-  - the final three lines of code make sure each dependency in our array is linked
-
-The reason we create an array is because sometimes our extension will have multiple native dependencies, so instead of making a separate linking command for each, we simply run one `forEach` loop and hand it an array of dependencies.
 
 ### Using the Package
 
@@ -320,4 +291,4 @@ Opening the QRReader app in the Builder will show us an app with no Screens, but
 
 This specific native dependency that we're using (`react-native-camera`) is already linked in the Builder preview binary, so we will be able to preview the there. Once it finishes building and loading our QRReader app, scan a QR code, like [this one](https://upload.wikimedia.org/wikipedia/commons/d/d0/QR_code_for_mobile_English_Wikipedia.svg), which should display the URL to WikiPedia's English mobile main page.
 
-With any other native dependency, previewing the app through the Builder won't be possible, because of it's predefined binary, so instead we have to [preview it locally](http://shoutem.github.io/docs/extensions/tutorials/setting-local-environment) using `react-native run-ios` or `react-native run-android`.
+With any other native dependency, previewing the app through the Builder won't be possible, because of its predefined binary, so instead we have to [preview it locally](http://shoutem.github.io/docs/extensions/tutorials/setting-local-environment) using `react-native run-ios` or `react-native run-android`.

--- a/docs/extensions/tutorials/_posts/1970-01-07-ModifyingNativeProject.md
+++ b/docs/extensions/tutorials/_posts/1970-01-07-ModifyingNativeProject.md
@@ -17,7 +17,7 @@ This section will elaborate on how to inject code into the native parts of the r
 
 #### Available anchors
 
-The list of available anchors can be seen in the [platform's helper scripts](https://github.com/shoutem/platform/blob/develop/scripts/helpers/const.js).
+The list of available anchors can be seen in the [platform's helper scripts](https://github.com/shoutem/platform/blob/master/scripts/helpers/const.js).
 
 The `ANCHORS` object is structured as follows:
 
@@ -58,7 +58,7 @@ build/
 
 We can look at the `shoutem.code-push` [extension](https://github.com/shoutem/extensions/tree/master/shoutem.code-push/app/build) as an example.
 
-`const.js` should contain all the plaintext modifications you need to inject, in separate variables, exported as a single object named after your extension, with a structure resembling that of the `ANCHORS` object from `@shoutem/build-tools` seen above in the **Available anchors** section and the platform's `scripts/helpers/const.js` [file](https://github.com/shoutem/platform/blob/develop/scripts/helpers/const.js).
+`const.js` should contain all the plaintext modifications you need to inject, in separate variables, exported as a single object named after your extension, with a structure resembling that of the `ANCHORS` object from `@shoutem/build-tools` seen above in the **Available anchors** section and the platform's `scripts/helpers/const.js` [file](https://github.com/shoutem/platform/blob/master/scripts/helpers/const.js).
 
 ```JavaScript
 #file: shoutem.code-push/app/build/const.js
@@ -198,4 +198,4 @@ Furthermore, unique parts of the Android module are merged from the extension in
 </manifest>
 ```
 
-There is no similar method for iOS, however, we've included `Info.plist` merging, so you can create an `{{ site.example.devName }}.extension-name/app/ios` directory and an `Info.plist` file inside of it, which will get merged into the root `Info.plist` by the platform's `merge-info-plists.js` [script](https://github.com/shoutem/platform/blob/develop/scripts/merge-info-plists.js) during the app's configuration. An example of this can be seen in the `shoutem.camera` [extension](https://github.com/shoutem/extensions/blob/master/shoutem.camera/app/ios/Info.plist), which adds permissions to the root `Info.plist`.
+There is no similar method for iOS, however, we've included `Info.plist` merging, so you can create an `{{ site.example.devName }}.extension-name/app/ios` directory and an `Info.plist` file inside of it, which will get merged into the root `Info.plist` by the platform's `merge-info-plists.js` [script](https://github.com/shoutem/platform/blob/master/scripts/merge-info-plists.js) during the app's configuration. An example of this can be seen in the `shoutem.camera` [extension](https://github.com/shoutem/extensions/blob/master/shoutem.camera/app/ios/Info.plist), which adds permissions to the root `Info.plist`.

--- a/docs/extensions/tutorials/_posts/1970-01-07-ModifyingNativeProject.md
+++ b/docs/extensions/tutorials/_posts/1970-01-07-ModifyingNativeProject.md
@@ -1,15 +1,15 @@
 ---
 layout: doc
-permalink: /docs/extensions/tutorials/modifying-root-app
+permalink: /docs/extensions/tutorials/modifying-native-project
 title: Modifying Root App
 section: Tutorials
 ---
 
-# Modifying Root App
+# Modifying Native Project
 
-When making an extension with native dependencies, it's often necessary to change properties outside of the extension. One way we address this need using anchors, which can be used to inject code into files which often need to be modified in order to set up a native dependency.
+When making an extension with native dependencies, it's often necessary to change properties outside of the extension. One way we address this need using file anchors, which can be used to inject code into files which often need to be modified in order to set up a native dependency.
 
-Another tool we provide is the merging of the extension's app segmenet into the root app. For example, instead of directly modifying the root Android `build.gradle`, you can simply create a `build.gradle` in  the `{{ site.example.devName }}.extension-name/app/android` directory which is then merged into the root `build.gradle`. You can see an example in `shoutem.places`, [here](https://github.com/shoutem/extensions/tree/master/shoutem.places/app/android).
+You can also affect the native project by creating an `android` and `ios` directory in the extension's app segment, you can read more about that in the [**App segment**]({{ site.url }}/docs/extensions/tutorials/modifying-native-project#app-segment) section.
 
 ## Injecting
 
@@ -181,11 +181,13 @@ The `inject()` and `replace()` functions can be used to either inject code at an
 - `newContent`: the source code that should replace `oldContent` in the file
 
 
-## Merging files
+## App segment
 
-As mentioned in the introduction, another tool provided for modifying the root app with an extension is to utilize the app segment merging.
+As mentioned in the introduction, another tool provided for modifying the root app with an extension is to define new Android modules using an `android` directory in the app segment of your extension.
 
-An example of this can be seen in our `shoutem.places` [extension](https://github.com/shoutem/extensions/tree/master/shoutem.places/app/android) in the `shoutem.places/app/android` directory. It merges, among other things, `AndroidManifest.xml` in order to add permissions for Internet and Location:
+For example, instead of directly modifying the root Android `build.gradle`, you can simply create a `build.gradle` in  the `{{ site.example.devName }}.extension-name/app/android` directory which defines a new Android module for the app. You can see an example in `shoutem.places`, [here](https://github.com/shoutem/extensions/tree/master/shoutem.places/app/android).
+
+Furthermore, unique parts of the Android module are merged from the extension into the app, such as the `AndroidManifest.xml`, also visible in the above `shoutem.places` example. You can read more about manifest merging [here](https://developer.android.com/studio/build/manifest-merge).
 
 ```XML
 #file: shoutem.places/app/android/src/main/AndroidManifest.xml
@@ -195,3 +197,5 @@ An example of this can be seen in our `shoutem.places` [extension](https://githu
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>
 ```
+
+There is no similar method for iOS, however, we've included `Info.plist` merging, so you can create an `{{ site.example.devName }}.extension-name/app/ios` directory and an `Info.plist` file inside of it, which will get merged into the root `Info.plist` by the platform's `merge-info-plists.js` [script](https://github.com/shoutem/platform/blob/develop/scripts/merge-info-plists.js) during the app's configuration. An example of this can be seen in the `shoutem.camera` [extension](https://github.com/shoutem/extensions/blob/master/shoutem.camera/app/ios/Info.plist), which adds permissions to the root `Info.plist`.

--- a/docs/extensions/tutorials/_posts/1970-01-07-ModifyingRootApp.md
+++ b/docs/extensions/tutorials/_posts/1970-01-07-ModifyingRootApp.md
@@ -1,0 +1,197 @@
+---
+layout: doc
+permalink: /docs/extensions/tutorials/modifying-root-app
+title: Modifying Root App
+section: Tutorials
+---
+
+# Modifying Root App
+
+When making an extension with native dependencies, it's often necessary to change properties outside of the extension. One way we address this need using anchors, which can be used to inject code into files which often need to be modified in order to set up a native dependency.
+
+Another tool we provide is the merging of the extension's app segmenet into the root app. For example, instead of directly modifying the root Android `build.gradle`, you can simply create a `build.gradle` in  the `{{ site.example.devName }}.extension-name/app/android` directory which is then merged into the root `build.gradle`. You can see an example in `shoutem.places`, [here](https://github.com/shoutem/extensions/tree/master/shoutem.places/app/android).
+
+## Injecting
+
+This section will elaborate on how to inject code into the native parts of the root app without leaving the extension.
+
+#### Available anchors
+
+The list of available anchors can be seen in the [platform's helper scripts](https://github.com/shoutem/platform/blob/develop/scripts/helpers/const.js).
+
+The `ANCHORS` object is structured as follows:
+
+```JavaScript
+#file: AppName/scripts/helpers/const.js
+const ANCHORS = {
+  IOS: {
+    PODFILE: {
+      EXTENSION_DEPENDENCIES: '## <Extension dependencies>',
+      EXTENSION_POSTINSTALL_TARGETS: '## <Extension postinstall targets>',
+    },
+    ...
+  },
+  ANDROID: {
+    MAIN_ACTIVITY: {
+      IMPORT: '//NativeModuleInjectionMark-mainActivity-import',
+      ON_CREATE: '//NativeModuleInjectionMark-mainActivity-onCreate',
+      ON_ACTIVITY_RESULT: '//NativeModuleInjectionMark-mainActivity-onActivityResult',
+      ON_ACTIVITY_RESULT_END: '//NativeModuleInjectionMark-mainActivity-onActivityResult-end',
+    },
+    ...
+  },
+};
+
+module.exports = {
+  ANCHORS,
+};
+```
+
+#### 'build' directory structuring
+
+```
+build/
+  ├ const.js
+  ├ inject{ExtensionName}{MobileOSName}.js
+  └ index.js
+```
+
+We can look at the `shoutem.code-push` [extension](https://github.com/shoutem/extensions/tree/master/shoutem.code-push/app/build) as an example.
+
+`const.js` should contain all the plaintext modifications you need to inject, in separate variables, exported as a single object named after your extension, with a structure resembling that of the `ANCHORS` object from `@shoutem/build-tools` seen above in the **Available anchors** section and the platform's `scripts/helpers/const.js` [file](https://github.com/shoutem/platform/blob/develop/scripts/helpers/const.js).
+
+```JavaScript
+#file: shoutem.code-push/app/build/const.js
+const codepush = {
+  ios: {
+    appDelegate: {
+      import: '#import <CodePush/CodePush.h>',
+      oldBundle: appDelegateOldBundle,
+      newBundle: appDelegateNewBundle,
+    },
+    ...
+  },
+  android: {
+    app: {
+      import: 'import com.microsoft.codepush.react.CodePush;',
+      ...
+    },
+  },
+};
+```
+
+`inject{ExtensionName}` should contain the functions which inject the code, one for Android and one for iOS, named `injectCodePushAndroid` and `injectCodePushIos`, respectively.
+
+```JavaScript
+#file: shoutem.code-push/app/build/injectCodePush.js
+const {
+  ANCHORS,
+  ...
+} = require('@shoutem/build-tools');
+const { codepush } = require('./const');
+
+function injectCodePushAndroid() {
+  // app/build.gradle mods
+  const gradleAppPath = getAppGradlePath({ cwd: projectPath });
+  inject(
+    gradleAppPath,
+    ANCHORS.ANDROID.GRADLE.APP.REACT_GRADLE,
+    codepush.android.app.gradle.codepushGradle,
+  );
+  ...
+}
+
+function injectCodePushIos() {
+  const appDelegate = getAppDelegatePath({ cwd: projectPath });
+  inject(appDelegate, ANCHORS.IOS.APP_DELEGATE.IMPORT, codepush.ios.appDelegate.import);
+  replace(appDelegate, codepush.ios.appDelegate.oldBundle, codepush.ios.appDelegate.newBundle);
+  ...
+}
+
+module.exports = {
+  injectCodePushAndroid,
+  injectCodePushIos,
+};
+```
+
+`index.js` should contain a single export, a `preBuild` function which will be called in the preBuild step of the `shoutem configure` lifecycle. The preBuild function itself should simply call the functions imported from the `inject{ExtensionName}.js` file.
+
+```JavaScript
+#file: shoutem.code-push/app/build/index.js
+const { injectCodePushAndroid, injectCodePushIos } = require('./injectCodePush');
+
+exports.preBuild = function preBuild() {
+  injectCodePushAndroid();
+  injectCodePushIos();
+}
+```
+
+#### inject{ExtensionName}{MobileOSName} convention
+
+- name your functions `inject{ExtensionName}{MobileOSName}`
+- start a new block by adding a comment declaring which file is going to be modified
+- assign that file's path to a new const
+- use inject() and/or replace() to apply modifications
+- create another block if more changes are needed
+
+The following example follows all of the above convention rules.
+
+```JavScript
+// app/settings.properties mods
+const gradlePropertiesPath = getGradlePropertiesPath({ cwd: projectPath });
+inject(
+  gradlePropertiesPath,
+  ANCHORS.ANDROID.GRADLE.PROPERTIES,
+  codepush.android.app.gradle.codepushKey,
+);
+
+// MainApplication.java mods
+const mainApplicationPath = getMainApplicationPath({ cwd: projectPath });
+inject(
+  mainApplicationPath,
+  ANCHORS.ANDROID.MAIN_APPLICATION.IMPORT,
+  codepush.android.app.import,
+);
+inject(
+  mainApplicationPath,
+  ANCHORS.ANDROID.MAIN_APPLICATION.RN_HOST_BODY,
+  codepush.android.app.rnHost,
+);
+inject(
+  mainApplicationPath,
+  ANCHORS.ANDROID.MAIN_APPLICATION.GET_PACKAGES,
+  codepush.android.app.getPackages,
+);
+```
+
+#### inject() and replace()
+
+The `inject()` and `replace()` functions can be used to either inject code at an anchor, or replace content in a specific file. Both functions will check if the code is already injected/replaced before doing so.
+
+**inject()** accepts the following arguments:
+
+- `filePath:` the path to the file that you need to modify
+- `anchor:` position in the file specified in the `ANCHORS` object
+- `contents`: the source code that needs to be injected at anchor position
+
+**replace()** accepts the following arguments:
+
+- `filePath:` the path to the file that you need to modify
+- `oldContent:` the source code to search for in the file
+- `newContent`: the source code that should replace `oldContent` in the file
+
+
+## Merging files
+
+As mentioned in the introduction, another tool provided for modifying the root app with an extension is to utilize the app segment merging.
+
+An example of this can be seen in our `shoutem.places` [extension](https://github.com/shoutem/extensions/tree/master/shoutem.places/app/android) in the `shoutem.places/app/android` directory. It merges, among other things, `AndroidManifest.xml` in order to add permissions for Internet and Location:
+
+```XML
+#file: shoutem.places/app/android/src/main/AndroidManifest.xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.shoutem.places">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+</manifest>
+```


### PR DESCRIPTION
Added `Modifying root app` docs which explain how to utilize android folder merging and `@shoutem/build-tools` anchors.

Also updated `Installing 3rd party packages` tutorial to utilize `@shoutem/build-tools`' `react-native-link` helper function.