### PR TITLE
#176 removed unnecessary link to missing Touchable component docs page

### DIFF
--- a/_includes/sidebar-nav.html
+++ b/_includes/sidebar-nav.html
@@ -91,7 +91,6 @@
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/view">View</a></li>
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/screen">Screen</a></li>
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/touchable-opacity">TouchableOpacity</a></li>
-					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/touchable">Touchable</a></li>
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/headers">Headers</a></li>
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/overlay">Overlay</a></li>
 					<li><a href="{{ site.baseurl }}/docs/ui-toolkit/components/text-input">TextInput</a></li>


### PR DESCRIPTION
This is a quick one line deletion to remove the Touchable links from the side navigation in the Docs.