### PR TITLE
Accessibility: Adding alt text to site images

### DIFF
--- a/docs/extensions/my-first-extension/_posts/1970-01-01-Introduction.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-01-Introduction.md
@@ -15,7 +15,7 @@ Before you start the My First Extension tutorial series, you should go through [
 Here's a preview of what the completed app will look like.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/extension-preview.jpg'/>
+<img alt='Preview of the Getting Started app' src='{{ site.url }}/img/my-first-extension/extension-preview.jpg'/>
 </p>
 
 ## What are Extensions?
@@ -23,7 +23,7 @@ Here's a preview of what the completed app will look like.
 Extensions represent features in the app. The app owner picks extensions that he wants to use in his app through the Shoutem Builder. Shoutem prepared a bunch of [open sourced](https://github.com/shoutem/extensions) extensions which you can easily customize to fit your needs.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/shoutem-extensions.png'/>
+<img alt='Gallery of extension icons' src='{{ site.url }}/img/my-first-extension/shoutem-extensions.png'/>
 </p>
 
 You can develop extensions both within apps made by `shoutem clone` and as stand-alone extensions that you plan on using within multiple apps. In this tutorial, we'll be working on the Restaurants extension we made in Getting Started, so it'll be treated as one within a _cloned_ app.
@@ -37,13 +37,13 @@ Shoutem uses [React](https://facebook.github.io/react/) and [React Native](https
 We use [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) as a simple way to write UI components with tags. Building an app screen with JSX is as easy as:
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/jsx-component-example.png'/>
+<img alt='Example jsx app code' src='{{ site.url }}/img/my-first-extension/jsx-component-example.png'/>
 </p>
 
 On top of React and React Native, we're using [Redux](http://redux.js.org/), a library which simplifies state management.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/redux.png'/>
+<img alt='Redux state flow chart' src='{{ site.url }}/img/my-first-extension/redux.png'/>
 </p>
 
 Even though _we_ use Redux, _you_ can use any other state management library (like [MobX](https://github.com/mobxjs/mobx), or just don't use any at all! Again, we don't want to restrict you on how you use React Native.

--- a/docs/extensions/my-first-extension/_posts/1970-01-03-InitializingExtension.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-03-InitializingExtension.md
@@ -10,7 +10,7 @@ section: My first extension
 Here's the mockup of the Restaurants extension that we saw in the [Introduction]({{ site.url }}/docs/extensions/my-first-extension/introduction). Through the course of this tutorial, we'll turn the **Restaurants** extension from [Getting Started]({{ site.url }}/docs/extensions/tutorials/getting-started) into this list of restaurants.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/extension-preview.jpg'/>
+<img alt='Preview of the Getting Started app' src='{{ site.url }}/img/my-first-extension/extension-preview.jpg'/>
 </p>
 
 The left app screen lists the restaurants and the right one shows the details of each specific restaurant when you tap on it.
@@ -97,7 +97,7 @@ See it in the builder: {{ site.shoutem.builderURL }}/app/{{ site.example.appId }
 Uploading the extension is self-explanatory, but let's elaborate on installing and uninstalling extensions. In the Builder, you can go to the `Extensions` tab to see which extensions are installed in your app. If you successfully installed your Restaurants extension from [Getting Started]({{ site.url }}/docs/extensions/tutorials/getting-started), you should see it there under the `Custom` category.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/extension-tab-extension.png'/>
+<img alt="Shoutem interface Custom tab" src='{{ site.url }}/img/my-first-extension/extension-tab-extension.png'/>
 </p>
 
 Extensions are installed into specific apps, not all apps on your account.

--- a/docs/extensions/my-first-extension/_posts/1970-01-04-CreatingShortcutAndScreen.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-04-CreatingShortcutAndScreen.md
@@ -103,7 +103,7 @@ Scanning folders for symlinks in /path/to/Restaurants/node_modules
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/getting-started/03-lets-eat.png'/>
+<img alt="Phone showing Let's Eat text" src='{{ site.url }}/img/tutorials/getting-started/03-lets-eat.png'/>
 </p>
 
 > #### Note
@@ -128,7 +128,7 @@ export default class List extends Component {
 After reloading the emulator, your new line of text should be visible immediately:
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/real-time-preview.png'/>
+<img alt="Phone showing Let's Eat, Can't do anything on an empty stomach" src='{{ site.url }}/img/my-first-extension/real-time-preview.png'/>
 </p>
 
 Your extension only has a simple screen right now, let's add some [UI components]({{ site.url }}/docs/extensions/my-first-extension/using-ui-toolkit).

--- a/docs/extensions/my-first-extension/_posts/1970-01-05-UsingUIToolkit.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-05-UsingUIToolkit.md
@@ -92,7 +92,7 @@ Success!
 The app preview will be shown after Shoutem bundles the new app. `List` is now showing the list of restaurants.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/extension-rich-list.png'/>
+<img alt='Phone showing list of restaurant photos and names' src='{{ site.url }}/img/my-first-extension/extension-rich-list.png'/>
 </p>
 
 This looks exactly how we wanted.
@@ -329,7 +329,7 @@ export default class Details extends PureComponent {
 Now when you reload the app and tap on a restaurant in the list, this is what you get:
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/extension-rich-details.png'/>
+<img alt='Phone showing information for Gaspard Brasserie' src='{{ site.url }}/img/my-first-extension/extension-rich-details.png'/>
 </p>
 
 If you aren't previewing with an [emulator on your local machine]({{ site.url }}/docs/extensions/tutorials/setting-local-environment), you will have to _push_ the extension:

--- a/docs/extensions/my-first-extension/_posts/1970-01-06-UsingCloudStorage.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-06-UsingCloudStorage.md
@@ -162,25 +162,25 @@ Success!
 Go to the [Builder]({{ shoutem.builderURL }}), open your app and select `Restaurants` under `Main navigation` to see the Shoutem CMS page.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/empty-cms-page.png'/>
+<img alt='Shoutem interface Restaurants tab' src='{{ site.url }}/img/my-first-extension/empty-cms-page.png'/>
 </p>
 
 Click on `Create Items` to start adding content. This will open a modal that contains the `CMS` interface, where you can manage the content for your extension. Apps that get content from the Shoutem CMS will immediately show new content once you edit or add it.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/empty-cms.png'/>
+<img alt='Restaurants tab with Add Item button' src='{{ site.url }}/img/my-first-extension/empty-cms.png'/>
 </p>
 
 Click on `Add item`. This will open a modal for inserting data for the `Restaurants` model, which you defined with your data schema.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/cms-modal.png'/>
+<img alt='Shoutem interface New Item form' src='{{ site.url }}/img/my-first-extension/cms-modal.png'/>
 </p>
 
 Add at least one restaurant. Now you can see the data in the CMS settings page of your Restaurants extension:
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/full-cms.png'/>
+<img alt='Shoutem interface Restaurants tab containing list of restaurant data' src='{{ site.url }}/img/my-first-extension/full-cms.png'/>
 </p>
 
 Although you've added some restaurants in the Builder, your extension is still coded to use static data from the `assets` folder you set up earlier in the tutorial series. Let's change that and start fetching the data from Shoutem Cloud Storage using the `@shoutem/redux-io` package.

--- a/docs/extensions/my-first-extension/_posts/1970-01-07-WorkingWithData.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-07-WorkingWithData.md
@@ -232,7 +232,7 @@ Success!
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/working-with-data.png'/>
+<img alt='Shoutem interface Restaurants tab containing list of restaurant data' src='{{ site.url }}/img/my-first-extension/working-with-data.png'/>
 </p>
 
 Works like a charm! You just made your first extension using the **Shoutem UI Toolkit** and **Shoutem Cloud Storage**. Great job!

--- a/docs/extensions/my-first-extension/_posts/1970-01-08-Publish.md
+++ b/docs/extensions/my-first-extension/_posts/1970-01-08-Publish.md
@@ -20,7 +20,7 @@ Version `0.0.1` of `Restaurants` extensions was published!
 Publish your app now to the stores. You can let Shoutem publish it for you to both stores (premium feature) or publish it manually following [our tutorial]({{ site.url }}/docs/extensions/tutorials/publish-your-app). Shoutem has developed an easy and intuitive process of app publishing. Simply insert information at one place and Shoutem will take care of the rest.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/setting-local-environment/settings.png'/>
+<img alt='Shoutem setting app info tab' src='{{ site.url }}/img/tutorials/setting-local-environment/settings.png'/>
 </p>
 
 ## Using the app dashboard!
@@ -30,13 +30,13 @@ Once the app hits the stores, the dashboard really starts to shine. You can mana
 To send push notifications, navigate to the _Push_ tab in the Builder and customize the push notification you want to send.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/push-notification.png'/>
+<img alt='Push notification settings tab containing form' src='{{ site.url }}/img/my-first-extension/push-notification.png'/>
 </p>
 
 Tracking what users are doing within your app is also in the palm of your hand with our _Stats_ tab.
 
 <p class="image">
-<img src='{{ site.url }}/img/my-first-extension/analytics.png'/>
+<img alt='App stats tab showing graph' src='{{ site.url }}/img/my-first-extension/analytics.png'/>
 </p>
 
 ## What's next?

--- a/docs/extensions/reference/_posts/1970-01-01-Overview.md
+++ b/docs/extensions/reference/_posts/1970-01-01-Overview.md
@@ -32,7 +32,7 @@ Our app architecture is completely modular. At the center of everything is only 
 Some of our extensions are `system` ones. They're hidden from our non technical app owners (who don't have a developer account registered). Only `shoutem` developer can create `system` extensions.
 
 <p class="image">
-<img src='{{ site.url }}/img/references/platform/system-extensions.png'/>
+<img alt='System tab containing extension types' src='{{ site.url }}/img/references/platform/system-extensions.png'/>
 </p>
 
 ##### Extension lifecycle

--- a/docs/extensions/reference/_posts/1970-01-04-SettingsTypesInExtension.md
+++ b/docs/extensions/reference/_posts/1970-01-04-SettingsTypesInExtension.md
@@ -82,7 +82,7 @@ Extension settings are global settings shared throughout all extension parts wit
 Settings pages meant for manipulating extension settings can be found in the `Extensions` tab for that extension. We call them `extension settings pages`.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/extension-tab-extension-restaurants-settings.png'/>
+<img alt='Shoutem extensions settings page' src='{{ site.url }}/img/tutorials/settings-theme/extension-tab-extension-restaurants-settings.png'/>
 </p>
 
 ##### Server side
@@ -146,7 +146,7 @@ Shortcut settings are settings shared throughout all the screens that were navig
 Settings pages meant for manipulating shortcut settings can be found next to app structure in the `Screens` tab.  We call them `shortcut settings pages`. Namely, for this example, there should be `Content` and `Settings`.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/screens-tab-extension-restaurants-settings.png'/>
+<img alt='Shortcut settings page' src='{{ site.url }}/img/tutorials/settings-theme/screens-tab-extension-restaurants-settings.png'/>
 </p>
 
 ##### Server side
@@ -226,7 +226,7 @@ Screen settings are layouts settings that hold information specific for that lay
 There's only 1 settings page per screen for manipulating screen settings. It's located in the `Layout` shortcut settings page, under the layout selector, when that screen is selected as the desired layout.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/screens-tab-extension-restaurants-layout-settings.png'/>
+<img alt="Layout options page for screens" src='{{ site.url }}/img/tutorials/settings-theme/screens-tab-extension-restaurants-layout-settings.png'/>
 </p>
 
 ##### Server side

--- a/docs/extensions/reference/_posts/1970-01-05-ThemeVariables.md
+++ b/docs/extensions/reference/_posts/1970-01-05-ThemeVariables.md
@@ -10,7 +10,7 @@ section: Reference
 Adjustment of theme is done through theme variables. These variables can be set through Shoutem builder, which interprets the variables schema.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-no_picker.png'/>
+<img alt='Page with theme options' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-no_picker.png'/>
 </p>
 
 ## Structure of variables schema file
@@ -99,7 +99,7 @@ Each variable of the same format thus _inherits_ values defined in `formats`, bu
 Variable of type color will result in color picker in interface for customizing theme.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-color.png'/>
+<img alt='Theme color selector' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-color.png'/>
 </p>
 
 ###### Default value
@@ -116,7 +116,7 @@ Currently, there are no additional properties variable descriptor supports.
 Variable of type font will result in complex control in interface for customizing theme.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-font.png'/>
+<img alt='Page with theme options' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-font.png'/>
 </p>
 
 

--- a/docs/extensions/tutorials/_posts/1970-01-01-ConnectToApi.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-ConnectToApi.md
@@ -12,7 +12,7 @@ Since Shoutem apps are plain React Native apps, you can connect to any API. It's
 In this tutorial we'll explain how to build a simple React Native app fetching the photo of the day from [NASA's APOD API](https://api.nasa.gov/index.html). We'll also use the [Shoutem UI toolkit]({{ site.url }}/docs/ui-toolkit/introduction). Here's how the completed app should look:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/connecting-to-api/final.png'/>
+<img alt="Phone with planet photo app' src='{{ site.url }}/img/tutorials/connecting-to-api/final.png'/>
 </p>
 
 The complete code for this extension is available in our [GitHub repository](https://github.com/shoutem/extension-examples/tree/master/connecting-to-3rd-party-api).
@@ -71,7 +71,7 @@ Extension successfully installed to the new app. Check it here:
 Once this is done, go to the [Builder]({{ site.shoutem.builderURL }}) and add the screen inside the app. Now you can preview the app:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/connecting-to-api/hello-world.png'/>
+<img alt='Shoutem interface screen builder tab' src='{{ site.url }}/img/tutorials/connecting-to-api/hello-world.png'/>
 </p>
 
 ## Fetch the Photo
@@ -158,5 +158,5 @@ Success!
 Preview it to see the changes. This is the final result:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/connecting-to-api/final-builder.png'/>
+<img alt='App navigation preview' src='{{ site.url }}/img/tutorials/connecting-to-api/final-builder.png'/>
 </p>

--- a/docs/extensions/tutorials/_posts/1970-01-01-PublishYourApp.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-PublishYourApp.md
@@ -68,7 +68,7 @@ Instead of going to each store to fill in app information, we've put everything 
 After you finish the first two steps, click the `Publish` button. Your app will go into the review process in both stores and we'll be notifying you of the process.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/publish-app.png'/>
+<img alt='Page with publish app button' src='{{ site.url }}/img/tutorials/publish-your-app/publish-app.png'/>
 </p>
 
 Once your app is published, the `Publish` button will become `Republish`.
@@ -148,19 +148,19 @@ Successfully signed ShoutemApp.ipa!
 Login to iTunes Connect with your iOS Developer account, click on `My Apps`, then click on the `+` in the top left corner. You should get this menu:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-connect-menu.png'/>
+<img alt='New app form' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-connect-menu.png'/>
 </p>
 
 Fill your app details. Once you are done with that, click on `Create`. Your app is now created on iTunes Connect and you are few steps away from publishing it. Fill the details of your app's privacy policy link, category and license agreement.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-app-info.png'/>
+<img alt='App information page' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-app-info.png'/>
 </p>
 
 In `Pricing and Availability`, choose to make your app free or paid and in which countries you want to make it available.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-pricing-and-availability.png'/>
+<img alt='Pricing and Availability tab with schedule' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-pricing-and-availability.png'/>
 </p>
 
 Upload app's metadata. Click on iOS app which is currently in “Prepare for Submission” state. On this screen, you will upload your app’s screenshots, add it’s description, keywords, support URL, content rating, app store artwork and review contact information.
@@ -168,7 +168,7 @@ Upload app's metadata. Click on iOS app which is currently in “Prepare for Sub
 After doing so, upload your build file (.ipa). To upload it, you use tool called Application Loader, which is one of the tools that comes along with Xcode. Find it in Xcode: Select Xcode in the menu -> Open Developer Tools -> Application Loader. This is what you should get:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/xcode-application-loader.png'/>
+<img alt='Apple ID Sign in' src='{{ site.url }}/img/tutorials/publish-your-app/xcode-application-loader.png'/>
 </p>
 
 Login with your iOS Developer account, choose the “Deliver your app” option and upload your .ipa file to iTunes Connect.
@@ -176,13 +176,13 @@ Login with your iOS Developer account, choose the “Deliver your app” option 
 After uploading it, the app will go trough processing time in iTunes Connect. Processing time can vary from few minutes to few hours (even days) and it depends on the stability of the Apple’s services. If you click on the `Activity tab` in iTunes Connect, you will see this while your app is in processing time:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-processing-time.png'/>
+<img alt='Tab showing iOS builds' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-processing-time.png'/>
 </p>
 
 Once the processing of your app is done, go back to your iOS app and scroll down to the `Build section`. You'll notice that a little `+` sign has appeared next to `Build`.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-build.png'/>
+<img alt="Interface to initiate build' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-build.png'/>
 </p>
 
 Click on it and the build of your app is processed and ready for preview. After adding a build, click on the `Submit for Review` button in the top right corner.
@@ -190,7 +190,7 @@ Click on it and the build of your app is processed and ready for preview. After 
 Finally, you need to declare your app's export compliance, content rights and advertising info:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/itunes-compilance.png'/>
+<img alt='Form with export options' src='{{ site.url }}/img/tutorials/publish-your-app/itunes-compilance.png'/>
 </p>
 
 Answer those questions and click the `Submit` button. Your app status will change to "Waiting for review" state which means that your app has been sent to Apple's review team.
@@ -272,13 +272,13 @@ $ ./zipalign -v 4 /path/to/unaligned.apk /path/for/release-aligned.apk
 Create your app in the Google Play Developer Console. Log in with your Android Developer account credentials and select `Add New Application` in the [Google Play Developer Console panel](https://play.google.com/apps/publish/):
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-create-app.png'/>
+<img alt='New application page' src='{{ site.url }}/img/tutorials/publish-your-app/android-create-app.png'/>
 </p>
 
 Once you’ve entered that information, you'll be taken to the `Store Listing` screen, where you need to update your app's short description, description, screenshots, featured graphics, category and application type and add link to your privacy policy:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-store-listing.png'/>
+<img alt='Developer Console store listing page' src='{{ site.url }}/img/tutorials/publish-your-app/android-store-listing.png'/>
 </p>
 
 #### Upload your App to Production
@@ -286,13 +286,13 @@ Once you’ve entered that information, you'll be taken to the `Store Listing` s
 Under the `App Releases` tab, choose how you want to publish your Android app - is it for production, beta or alpha:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-app-releases.png'/>
+<img alt="Production, beta, and alpha release options page' src='{{ site.url }}/img/tutorials/publish-your-app/android-app-releases.png'/>
 </p>
 
 The process is pretty much the same for each release, so we will cover production release. Click on `Manage production` and then on `Create New`. This will take you to:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-new-release-to-production.png'/>
+<img alt='App release page with APK options' src='{{ site.url }}/img/tutorials/publish-your-app/android-new-release-to-production.png'/>
 </p>
 
 Here you can upload your .apk file, choose the release name and "What's Next" text. Once you're done, click on `Review`.
@@ -302,13 +302,13 @@ Here you can upload your .apk file, choose the release name and "What's Next" te
 Answer Google's content rating questionnaire and choose your app’s content category. Add your email address and choose from one of six available categories.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-content-rating.png'/>
+<img alt='Content rating questionnaire' src='{{ site.url }}/img/tutorials/publish-your-app/android-content-rating.png'/>
 </p>
 
 Each category contains slightly different questions which need to be answered mostly as Yes/No questions. Click `Save questionnaire`, then `Calculate rating`. You will see the ratings for the various locales where your app may be on sale. Scroll to the bottom of the list and click `Apply rating`. The `Content Rating` check mark is now green.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-rating-details.png'/>
+<img alt='Rating questionnaire summary' src='{{ site.url }}/img/tutorials/publish-your-app/android-rating-details.png'/>
 </p>
 
 #### Pricing and Distribution
@@ -316,13 +316,13 @@ Each category contains slightly different questions which need to be answered mo
 Select the `Pricing & Distribution` check mark for the final step: setting the price of your app and in which countries it will be available.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-pricing-and-distrution.png'/>
+<img alt='Distribution selector for countries' src='{{ site.url }}/img/tutorials/publish-your-app/android-pricing-and-distrution.png'/>
 </p>
 
 Below this, there are a few checkbox questions regarding your app distribution. Check the boxes by Content guidelines and US export laws to indicate your app’s compliance with relevant rules, then scroll to the top of the page and click `Save draft`.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-content-guidelines.png'/>
+<img alt="List of device categories' src='{{ site.url }}/img/tutorials/publish-your-app/android-content-guidelines.png'/>
 </p>
 
 ### Release the App
@@ -330,7 +330,7 @@ Below this, there are a few checkbox questions regarding your app distribution. 
 Select your `App Release` tab again and select `Edit release` under `Manage Production`:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/publish-your-app/android-app-release.png'/>
+<img alt="App release page' src='{{ site.url }}/img/tutorials/publish-your-app/android-app-release.png'/>
 </p>
 
 Scroll down, click on the `Review` button. Check your app details and if you are satisfied, click on the `Start rollout to production` button to publish your app in the `Google Play Store`. Clicking on the confirm button, you will publish your app in the Store!

--- a/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
+++ b/docs/extensions/tutorials/_posts/1970-01-01-SettingLocalEnvironment.md
@@ -18,7 +18,7 @@ There are limitations to what the Builder can preview. Namely, it can only previ
 To work on apps with native code changes, you can use `react-native run-ios` and `react-native run-android` inside your cloned app's directory, the same way you'd use them with any other React Native app! You can find out how to set up your local environment for React Native development using [Facebook's official documentation](https://facebook.github.io/react-native/docs/getting-started.html). Make sure you strictly pass through all the steps described there.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/setting-local-environment/rn-getting-started.png'/>
+<img alt='React Native Getting Started page' src='{{ site.url }}/img/tutorials/setting-local-environment/rn-getting-started.png'/>
 </p>
 
 Once you have that set up, you can continue your work like it was a regular React Native app.

--- a/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
+++ b/docs/extensions/tutorials/_posts/1970-01-02-WritingATheme.md
@@ -133,7 +133,7 @@ Success!
 Since the Restaurants extension is already installed, so is your theme. However, it's not applied yet. Navigate to the `Styles` tab. Currently, the selected theme is `Rubicon`, clearly no match for your gorgeous new theme, so let's fix that. Click on the `Change theme` button. Here you can find every installed theme. Yours is also there! Select it and you'll see the showcase you set up for it earlier.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-theme-change_theme-theme_showcase.png'/>
+<img alt='Phone showing list of restaurants' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-theme-change_theme-theme_showcase.png'/>
 </p>
 
 Select `Apply theme`.
@@ -141,7 +141,7 @@ Select `Apply theme`.
 Now check the `Customize theme` tab.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-no_picker.png'/>
+<img alt='Theme tab with colors and fonts' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-no_picker.png'/>
 </p>
 
 Here the app owner can customize your theme through theme variables. These variables can be found in `server/themes/restaurantVariables.json` and they're a copy of the [Rubicon theme variables](https://github.com/shoutem/extensions/blob/master/shoutem-rubicon-theme/server/primeThemeVariables.json).
@@ -312,7 +312,7 @@ Success!
 Now open the app in the Builder preview.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-font.png'/>
+<img alt='Theme customization tab' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customize_theme-font.png'/>
 </p>
 
 This is good, but what if we got a request from people using our theme that they want to be able to modify subtitle text color? We can do that with variables, so they don't have to even leave the Builder.
@@ -383,7 +383,7 @@ Success!
 Check `Customize theme` under the `Style` tab. You can see the `Restaurants` section with a color picker for subtitle text color. Well done!
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-color_picker_preview.png'/>
+<img alt='Theme tab color selector' src='{{ site.url }}/img/tutorials/settings-theme/style-tab-themes-customise_theme-color_picker_preview.png'/>
 </p>
 
 ## Adding a Custom Font
@@ -427,7 +427,7 @@ In order to be able to choose the font you've added through the Builder, it has 
 After that, you can _push_ your extension to update the changes you've made on the Builder. After choosing your newly created theme you will be able to use the custom font you added:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/custom-font.png'/>
+<img alt='Typography customization tab' src='{{ site.url }}/img/tutorials/settings-theme/custom-font.png'/>
 </p>
 
 However, you won't be able to preview these changes in the Builder. This is because fonts are linked into the binary of the app, while the Builder previews as a predefined binary and only previews JavaScript bundle changes. So to be able to preview this you'll have to set up your local development environment so the custom font is linked into the local binary. You can find out how to do that [here]({{ site.url }}/docs/extensions/tutorials/setting-local-environment).
@@ -438,7 +438,7 @@ However, you won't be able to preview these changes in the Builder. This is beca
 Here you can see the difference between `Noto Serif` (left), a font included in our default theme, and our example custom font `Roboto Regular` (right):
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/custom-font-difference.png'/>
+<img alt='Two restaurant lists using different fonts' src='{{ site.url }}/img/tutorials/settings-theme/custom-font-difference.png'/>
 </p>
 
 ## Adding a Custom Icon to the Builder
@@ -446,7 +446,7 @@ Here you can see the difference between `Noto Serif` (left), a font included in 
 Icons in the Builder are used to customize your app's icons in the Main navigation's different layouts:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/main-navigation-icons.png'/>
+<img alt='Navigation screens tab' src='{{ site.url }}/img/tutorials/settings-theme/main-navigation-icons.png'/>
 </p>
 
 When creating an app, you may want to use your own custom icon for the Main navigation, for instance you want to add a restaurant related icon for your Restaurants extension's screen.
@@ -500,7 +500,7 @@ You can see this in our [Rubicon theme](https://github.com/shoutem/extensions/bl
 Now you can simply _push_ to update your extension on Shoutem and once you open your Restaurants app in the Builder and check the Main navigation icons you can see your new icon under the `Theme icons` category.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/settings-theme/custom-icon.png'/>
+<img alt='Gallery of theme icons' src='{{ site.url }}/img/tutorials/settings-theme/custom-icon.png'/>
 </p>
 
 The other icons you see are a copy of the icons provided by the [Rubicon theme](https://github.com/shoutem/extensions/tree/master/shoutem-rubicon-theme/server/assets/icons), because, like we said, when you create a custom theme you're making a copy of Rubicon.

--- a/docs/extensions/tutorials/_posts/1970-01-03-ScreenLayouts.md
+++ b/docs/extensions/tutorials/_posts/1970-01-03-ScreenLayouts.md
@@ -15,7 +15,7 @@ We’ll create a different layout in the **Restaurants** extension from the [My 
 Let’s add one additional screen that will represent an alternative layout for the `List` screen where we'll use smaller images as shown here:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/screen-layouts/list-small.png'/>
+<img alt='Two list layouts side by side' src='{{ site.url }}/img/tutorials/screen-layouts/list-small.png'/>
 </p>
 
 Switch over to the extension folder:
@@ -98,7 +98,7 @@ The Restaurants extension uses `CMS settings page`, so app owners can manage dat
 The layout settings page resolves which screens have multiple layouts and shows the `layout selectors` for them. Example of two layout selectors for Shoutem's News RSS extension is shown below.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/screen-layouts/news-rss-layouts.png'/>
+<img alt='Navigation Screens Layout tab' src='{{ site.url }}/img/tutorials/screen-layouts/news-rss-layouts.png'/>
 </p>
 
 For the layout settings page to be able to resolve which screens should show layout selectors, we need to add the `extends` property to screens which act as additional layouts, referencing the "default" layout. Screen layouts inherit all the properties from extending screens and can override them.
@@ -166,7 +166,7 @@ Success!
 By default, the layout will be the `List` screen. Switch to `Layout` and select **List with small images**. This is the result you should get:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/screen-layouts/restaurants-small-list.png'/>
+<img alt='Screen layout tab' src='{{ site.url }}/img/tutorials/screen-layouts/restaurants-small-list.png'/>
 </p>
 
 Great job! Now you know how to create additional layouts for your extension.

--- a/docs/extensions/tutorials/_posts/1970-01-04-WritingReactSettingsPage.md
+++ b/docs/extensions/tutorials/_posts/1970-01-04-WritingReactSettingsPage.md
@@ -331,7 +331,7 @@ See it in browser: {{ site.shoutem.builderURL }}/{{ site.example.appId }}
 Our default setting applies and the app owner has an input form to change the `greeting` value.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom.png'/>
+<img alt='Screens page Hello World text' src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom.png'/>
 </p>
 
 ## Extension settings pages
@@ -483,7 +483,7 @@ Success!
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-shoutem.png'/>
+<img alt='Hello World screen showing Shoutem company' src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-shoutem.png'/>
 </p>
 
 So what's the purpose of extension settings pages as opposed to shortcut? Well, in our simple example, we made an extension where the app owner can define which company he's addressing and then make each Screen he adds on the Builder greet a unique employee. Each screen added will address the company defined in the Extension settings pages, while the app owner can choose which employee each screen greets.

--- a/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
+++ b/docs/extensions/tutorials/_posts/1970-01-05-Installing3rdPartyPackages.md
@@ -155,7 +155,7 @@ See it in browser: `{{ site.shoutem.builderURL }}/app/{{ site.example.appId }}`
 Opening the SwiperApp in the Builder will show us an app with no Screens, but since we just installed our Swiper Extension onto the app, we can just add the Swiper screen to it by clicking on the + button next to Screens, going to the Custom category and selecting the Swiper Extension. As soon as it's loaded into the Main Navigation we can preview the app:
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/installing-3rd-party-and-native-packages/swiper-in-preview.png'/>
+<img alt="Empty screen preview page' src='{{ site.url }}/img/tutorials/installing-3rd-party-and-native-packages/swiper-in-preview.png'/>
 </p>
 
 ## 2) Installing a Native Package

--- a/docs/extensions/tutorials/_posts/1970-01-08-ModifiyingExtensions.md
+++ b/docs/extensions/tutorials/_posts/1970-01-08-ModifiyingExtensions.md
@@ -27,7 +27,7 @@ For the purpose of this demo, create a new blank app and add a **News RSS** scre
 This is what it should look like (images and text vary with RSS feed):
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/modifying-extensions/provided-layouts.png'/>
+<img alt='Screens layout page' src='{{ site.url }}/img/tutorials/modifying-extensions/provided-layouts.png'/>
 </p>
 
 You do want list layout, but with large images in `Tiles`, such as the ones provided in the [UI toolkit]({{ site.url }}/docs/ui-toolkit/components/tiles). So let's modify News RSS extension directly to get those large images.
@@ -118,7 +118,7 @@ Delete the old News RSS screen from the navigation (click on the `...` in the to
 This is what you should get (images and text vary with RSS feed):
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/modifying-extensions/customized-list-layout.png'/>
+<img alt='Screens layout page' src='{{ site.url }}/img/tutorials/modifying-extensions/customized-list-layout.png'/>
 </p>
 
 This is what we wanted! It was quite easy and straightforward. However, doing this means creating a completely separate extension which won't get any updates done by Shoutem on Shoutem's **News RSS** extension.
@@ -318,7 +318,7 @@ Open your new app in the Builder. Now, add a screen from the **Shoutem** News RS
 Add an RSS feed in the **Content** tab, select the new layout in the **Layout** tab and run the app. This is what you should get (images and text vary with RSS feed):
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/modifying-extensions/new-layout.png'/>
+<img alt='Screens layout page' src='{{ site.url }}/img/tutorials/modifying-extensions/new-layout.png'/>
 </p>
 
 This way, we only extended Shoutem's **News RSS** extension and our extension will automatically get the all updates from Shoutem.

--- a/docs/extensions/tutorials/_posts/1970-01-11-WritingHTMLSettingsPages.md
+++ b/docs/extensions/tutorials/_posts/1970-01-11-WritingHTMLSettingsPages.md
@@ -311,7 +311,7 @@ See it in browser: {{ site.shoutem.builderURL }}/{{ site.example.appId }}
 Our default setting applies and the app owner has an input form to change the `greeting` value.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-html.png'/>
+<img alt='Screens Hello World page with name customization' src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-html.png'/>
 </p>
 
 ## Extension settings pages
@@ -451,7 +451,7 @@ Success!
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-shoutem-html.png'/>
+<img alt='Screens Hello World page with Shoutem company customization' src='{{ site.url }}/img/tutorials/writting-settings-page/hello-tom-shoutem-html.png'/>
 </p>
 
 So what's the purpose of extension settings pages as opposed to shortcut? Well, in our simple example, we made an extension where the app owner can define which company he's addressing and then make each Screen he adds on the Builder greet a unique employee. Each screen added will address the company defined in the Extension settings pages, while the app owner can choose which employee each screen greets.

--- a/docs/extensions/tutorials/_posts/1970-01-12-SettingsPageIntro.md
+++ b/docs/extensions/tutorials/_posts/1970-01-12-SettingsPageIntro.md
@@ -39,7 +39,7 @@ An example of this type of settings page was mentioned above, the User Authentic
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/extension-settings-page.png'/>
+<img alt='Extension user authentication tab' src='{{ site.url }}/img/tutorials/writting-settings-page/extension-settings-page.png'/>
 </p>
 
 ### Shortcut settings pages
@@ -69,7 +69,7 @@ An example of this type of settings page can be found in the News RSS extension:
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/shortcut-settings-page.png'/>
+<img alt='Screens tab content log' src='{{ site.url }}/img/tutorials/writting-settings-page/shortcut-settings-page.png'/>
 </p>
 
 ### Screen settings page
@@ -95,7 +95,7 @@ It's defined as `settingsPage` in the `screens`field as a single page for adjust
 ```
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/writting-settings-page/screen-settings-page.png'/>
+<img alt="Screens tab navigation' src='{{ site.url }}/img/tutorials/writting-settings-page/screen-settings-page.png'/>
 </p>
 
 Now that we understand the differences between settings pages, let's see [how to make them]({{ site.url }}/docs/extensions/tutorials/writing-react-settings-page).

--- a/docs/extensions/tutorials/_posts/1970-01-13-UsingLocalization.md
+++ b/docs/extensions/tutorials/_posts/1970-01-13-UsingLocalization.md
@@ -12,7 +12,7 @@ i18n stands for internationalization (i, 18 letters, n). Shoutem's localization 
 Language files are uploaded by the app owner using the `shoutem.i18n` settings page.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/localization/i18n-settings-page.png'/>
+<img alt='Shoutem interface Language and Region tab' src='{{ site.url }}/img/tutorials/localization/i18n-settings-page.png'/>
 </p>
 
 ## Translating your App

--- a/docs/extensions/tutorials/_posts/1970-01-14-SettingUpInstagram.md
+++ b/docs/extensions/tutorials/_posts/1970-01-14-SettingUpInstagram.md
@@ -18,7 +18,7 @@ In order to show an Instagram feed in a Shoutem app using the Photos RSS, you wi
 #### 2) Un-check the `Disable implicit 0Auth` setting.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/instagram/instagram-client.png'/>
+<img alt='Manage clients screen' src='{{ site.url }}/img/tutorials/instagram/instagram-client.png'/>
 </p>
 
 #### 3) Update the client.
@@ -37,7 +37,7 @@ At this point your browser may warn you that it requires you to authorize access
 #### 5) You can find the token after the # symbol in the address bar of your browser.
 
 <p class="image">
-<img src='{{ site.url }}/img/tutorials/instagram/access-token.png'/>
+<img alt='URL with access token' src='{{ site.url }}/img/tutorials/instagram/access-token.png'/>
 </p>
 
 ## How to generate a content URL for Shoutem


### PR DESCRIPTION
## Summary

On the [Shoutem documentation site](https://shoutem.github.io/docs/extensions/tutorials/getting-started), many images are not tagged with alt-text or aria labels. This poses an accessibility issue, as these images are not accessible without being able to visually understand the context and importance of the image. 

## Background

Per the ADA, sites should be accessible to all users. Those who use screen readers or other accessibility tools may rely on alt text describing images or graphics. This alt-text requirement is codified in the [WCAG 2.0 ](https://www.w3.org/TR/WCAG20/) from 2008, in [Section 1.1.1](http://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv.html) which states that any image or graphic other than those which are purely decorative or formatting should have alternative text which describes all information a user might glean from it visually.

## Example of Good Alt Text

Good alt text would be concisely and completely describing the contents of an image. For example, 

<img src="https://github.aexp.com/storage/user/48039/files/a632913c-21cb-46f4-81f8-dd3dd94941af" width="200" >

```
<img alt="Two phones showing views of Getting Started app"
 src="https://shoutem.github.io/img/my-first-extension/extension-preview.jpg">
```

### Your Proposal for Changes

The diff in this PR shows changes to the `img` attributes in the docs adding descriptive alt text.